### PR TITLE
New villagers endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -379,7 +379,7 @@ def format_villager(data):
                     'sub-personality': obj['nh_sub-personality'],
                     'catchphrase': obj['nh_catchphrase'],
                     'clothing': obj['nh_clothing'],
-                    'clothing_variation': obj['nh_clothing_variation'],
+                    'clothing_variation': obj['nh_clothing_variation'].replace('amp;', ''),
                     'fav_styles': [],
                     'fav_colors': [],
                     'hobby': obj['nh_hobby'],

--- a/app.py
+++ b/app.py
@@ -401,7 +401,7 @@ def get_villager_list(limit, tables, fields):
         species_list = ['alligator', 'anteater', 'bear', 'bird', 'bull', 'cat', 'cub', 'chicken', 'cow', 'deer', 'dog', 'duck', 'eagle', 'elephant', 'frog', 'goat', 'gorilla', 'hamster', 'hippo', 'horse', 'koala', 'kangaroo', 'lion', 'monkey', 'mouse', 'octopus', 'ostrich', 'penguin', 'pig', 'rabbit', 'rhino', 'sheep', 'squirrel', 'tiger', 'wolf']
         species = request.args.get('species').lower()
         if species not in species_list:
-            abort(400, description=error_response("Could not recognize provided personality.", "Ensure provided species is valid."))
+            abort(400, description=error_response("Could not recognize provided species.", "Ensure provided species is valid."))
 
         if where:
             where = where + ' AND species = "' + species + '"'

--- a/app.py
+++ b/app.py
@@ -377,7 +377,7 @@ def format_villager(data):
                     games_array.append(key.upper())
         for i in ['dnm', 'ac', 'e_plus', 'ww', 'cf', 'nl', 'wa', 'nh', 'film', 'hhd', 'pc']:
             del obj[i]
-        obj['games_array'] = games_array
+        obj['games'] = games_array
 
     return data
 

--- a/app.py
+++ b/app.py
@@ -377,7 +377,7 @@ def format_villager(data):
                     games_array.append(key.upper())
         for i in ['dnm', 'ac', 'e_plus', 'ww', 'cf', 'nl', 'wa', 'nh', 'film', 'hhd', 'pc']:
             del obj[i]
-        obj['games'] = games_array
+        obj['appearances'] = games_array
 
     return data
 

--- a/app.py
+++ b/app.py
@@ -387,7 +387,7 @@ def format_villager(data):
                     'house_exterior_url': obj['nh_house_exterior_url'],
                     'house_wallpaper': obj['nh_wallpaper'],
                     'house_flooring': obj['nh_flooring'],
-                    'house_music': obj['nh_music'],
+                    'house_music': obj['nh_music'].replace('amp;', ''),
                     'house_music_note': obj['nh_music_note']
                 }
                 if obj['nh_fav_style1']:

--- a/static/doc.json
+++ b/static/doc.json
@@ -11,7 +11,7 @@
     }
   ],
   "paths": {
-    "/villager": {
+    "/villagers": {
       "get": {
         "summary": "Villagers",
         "description": "This endpoint retrieves villager information from the entire Animal Crossing series, with the option to filter by species, personality, game, and/or birthday. Filters use the AND operator (e.g. asking for villagers who have species `frog` and personality `smug` will return all smug frogs). Note that villagers only include the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",

--- a/static/doc.json
+++ b/static/doc.json
@@ -13,7 +13,7 @@
   "paths": {
     "/villager": {
       "get": {
-        "summary": "All villagers",
+        "summary": "Villagers",
         "description": "All villagers from the entire Animal Crossing series, with the option to filter by species and/or personality. Note that villagers only includes the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",
         "parameters": [
           {
@@ -133,153 +133,12 @@
               }
             }
           },
-          "401": {
-            "description": "Failed to authenticate user from `X-API-KEY`.",
+          "400": {
+            "description": "One of the inputs (usually query parameters) has an invalid value.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Error401"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "There was an error fetching the requested data.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error500"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/villager/{villager}": {
-      "get": {
-        "summary": "Single villager",
-        "description": "Retrieve information about a specific villager. Note that villagers only includes the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "villager",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "The name of the villager you wish to retrieve information about."
-          },
-          {
-            "in": "header",
-            "name": "X-API-KEY",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Your UUID secret key, granted to you by the Nookipedia team. Required for accessing the API."
-          },
-          {
-            "in": "header",
-            "name": "Accept-Version",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
-          },
-          {
-            "in": "query",
-            "name": "species",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "alligator",
-                "anteater",
-                "bear",
-                "bird",
-                "bull",
-                "cat",
-                "cub",
-                "chicken",
-                "cow",
-                "deer",
-                "dog",
-                "duck",
-                "eagle",
-                "elephant",
-                "frog",
-                "goat",
-                "gorilla",
-                "hamster",
-                "hippo",
-                "horse",
-                "koala",
-                "kangaroo",
-                "lion",
-                "monkey",
-                "mouse",
-                "octopus",
-                "ostrich",
-                "penguin",
-                "pig",
-                "rabbit",
-                "rhino",
-                "sheep",
-                "squirrel",
-                "tiger",
-                "wolf"
-              ]
-            },
-            "description": "Retrieve villagers of a certain species."
-          },
-          {
-            "in": "query",
-            "name": "personality",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "lazy",
-                "jock",
-                "cranky",
-                "smug",
-                "normal",
-                "peppy",
-                "snooty",
-                "sisterly"
-              ]
-            },
-            "description": "Retrieve villagers with a certain personality. For 'sisterly', note that the community often also calls it 'uchi' or 'big sister'."
-          },
-          {
-            "in": "query",
-            "name": "excludedetails",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "When set to `true`, only villager names are returned. Instead of an array of objects with all details, the return will be an array of strings."
-          },
-          {
-            "in": "query",
-            "name": "thumbsize",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            },
-            "description": "Specify the desired width of returned image URLs. When unspecified, the linked image(s) returned by the API will be full-resolution. Note that images can only be reduced in size; specifying a width greater than than the maximum size will return the default full-size image URL. This parameter is generally not recommended unless you absolutely need it, as each returned thumbnail link with a custom size requires an additional network call, which can result in a long response time if calling this endpoint in between cache refreshes."
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "A JSON object describing the villager.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Villager"
                 }
               }
             }
@@ -290,16 +149,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Error401"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Could not find the specified villager.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error404"
                 }
               }
             }

--- a/static/doc.json
+++ b/static/doc.json
@@ -2,8 +2,8 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Nookipedia",
-    "description": "The Nookipedia API provides endpoints for retrieving Animal Crossing data pulled from the [Nookipedia wiki](https://nookipedia.com/wiki/Main_Page). A couple of the key benefits of using the Nookipedia API is access to data spanning the entire *Animal Crossing* series, as well as information that is constantly updated and expanding as editors work on the wiki.<br><br>This API launched in July 2020 and is under active development. At the moment, we currently have endpoints to retrieve information about *Animal Crossing: New Horizons* bugs, fish, and sea creatures. Coming very soon is data on all *Animal Crossing* villagers. In the horizon are endpoints for *New Horizons* furniture and clothing, as well as critters from previous games.<br><br>Access to the Nookipedia API requires obtaining a key. This is so we can manage our scale and provide better support for our users. To request access to the API, please fill out [this form](https://forms.gle/wLwtXLerKhfDrRLY8).<br><br>This API is 'version 2' of our [original API](https://nookipedia.com/api/). While the previous API scraped information directly from the wiki, this new edition of the API pulls data from a structured and constrained database, resulting in higher-quality data, better searching, and support for filtering.",
-    "version": "1.0.1"
+    "description": "The Nookipedia API provides endpoints for retrieving Animal Crossing data pulled from the [Nookipedia wiki](https://nookipedia.com/wiki/Main_Page). A couple of the key benefits of using the Nookipedia API is access to data spanning the entire *Animal Crossing* series, as well as information that is constantly updated and expanding as editors work on the wiki.<br><br>This API launched in July 2020 and is under active development. At the moment, we currently have endpoints to retrieve information about *Animal Crossing* villagers, as well as *Animal Crossing: New Horizons* bugs, fish, and sea creatures. In the horizon are endpoints for *New Horizons* furniture and clothing, as well as critters from previous games.<br><br>Access to the Nookipedia API requires obtaining a key. This is so we can manage our scale and provide better support for our users. To request access to the API, please fill out [this form](https://forms.gle/wLwtXLerKhfDrRLY8).<br><br>This API is 'version 2' of our [original API](https://nookipedia.com/api/). While the previous API scraped information directly from the wiki, this new edition of the API pulls data from a structured and constrained database, resulting in higher-quality data, better searching, and support for filtering.",
+    "version": "1.2.0"
   },
   "servers": [
     {
@@ -11,6 +11,151 @@
     }
   ],
   "paths": {
+    "/villager": {
+      "get": {
+        "summary": "All villagers",
+        "description": "All villagers from the entire Animal Crossing series. Note that villagers only includes the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-API-KEY",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Your UUID secret key, granted to you by the Nookipedia team. Required for accessing the API."
+          },
+          {
+            "in": "header",
+            "name": "Accept-Version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
+          },
+          {
+            "in": "query",
+            "name": "species",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "alligator",
+                "anteater",
+                "bear",
+                "bird",
+                "bull",
+                "cat",
+                "cub",
+                "chicken",
+                "cow",
+                "deer",
+                "dog",
+                "duck",
+                "eagle",
+                "elephant",
+                "frog",
+                "goat",
+                "gorilla",
+                "hamster",
+                "hippo",
+                "horse",
+                "koala",
+                "kangaroo",
+                "lion",
+                "monkey",
+                "mouse",
+                "octopus",
+                "ostrich",
+                "penguin",
+                "pig",
+                "rabbit",
+                "rhino",
+                "sheep",
+                "squirrel",
+                "tiger",
+                "wolf"
+              ]
+            },
+            "description": "Retrieve villagers of a certain species."
+          },
+          {
+            "in": "query",
+            "name": "personality",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "lazy",
+                "jock",
+                "cranky",
+                "smug",
+                "normal",
+                "peppy",
+                "snooty",
+                "sisterly"
+              ]
+            },
+            "description": "Retrieve villagers with a certain personality. For 'sisterly', that the community often also calls it 'uchi' or 'big sister'."
+          },
+          {
+            "in": "query",
+            "name": "excludedetails",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "When set to `true`, only fish names are returned. Instead of an array of objects with all details, the return will be an array of strings. This is particularly useful when used with the `month` filter, for users who want just a list of fish in a given month but not all their respective details."
+          },
+          {
+            "in": "query",
+            "name": "thumbsize",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Specify the desired width of returned image URLs. When unspecified, the linked image(s) returned by the API will be full-resolution. Note that images can only be reduced in size; specifying a width greater than than the maximum size will return the default full-size image URL. This parameter is generally not recommended unless you absolutely need it, as each returned thumbnail link with a custom size requires an additional network call, which can result in a long response time if calling this endpoint in between cache refreshes."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A JSON array of villagers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Villager"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Failed to authenticate user from `X-API-KEY`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error401"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was an error fetching the requested data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error500"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/nh/fish": {
       "get": {
         "summary": "All New Horizons fish",
@@ -33,7 +178,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The version of the API you are calling, written as `1.0.0`. This header is required as good practice, but is not currently utilized by the API as there is only one version at the moment."
+            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
           },
           {
             "in": "query",
@@ -131,7 +276,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The version of the API you are calling, written as `1.0.0`. This header is required as good practice, but is not currently utilized by the API as there is only one version at the moment."
+            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
           },
           {
             "in": "query",
@@ -209,7 +354,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The version of the API you are calling, written as `1.0.0`. This header is required as good practice, but is not currently utilized by the API as there is only one version at the moment."
+            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
           },
           {
             "in": "query",
@@ -307,7 +452,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The version of the API you are calling, written as `1.0.0`. This header is required as good practice, but is not currently utilized by the API as there is only one version at the moment."
+            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
           },
           {
             "in": "query",
@@ -385,7 +530,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The version of the API you are calling, written as `1.0.0`. This header is required as good practice, but is not currently utilized by the API as there is only one version at the moment."
+            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
           },
           {
             "in": "query",
@@ -483,7 +628,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The version of the API you are calling, written as `1.0.0`. This header is required as good practice, but is not currently utilized by the API as there is only one version at the moment."
+            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
           },
           {
             "in": "query",
@@ -542,7 +687,24 @@
   },
   "components": {
     "schemas": {
+      "Error400": {
+        "description": "Bad request (often an invalid input).",
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "example": "Failed to identify the provided month filter.",
+            "description": "A brief title describing the error."
+          },
+          "details": {
+            "type": "string",
+            "example": "Provided month filter jonuary was not recognized as a valid month.",
+            "description": "A more in-depth description of the issue, including parameters and/or error text when available."
+          }
+        }
+      },
       "Error401": {
+        "description": "Unauthorized.",
         "type": "object",
         "properties": {
           "title": {
@@ -552,12 +714,13 @@
           },
           "details": {
             "type": "string",
-            "example": "Provided month filter currentd was not recognized as a valid month.",
-            "description": "UUID is either missing or invalid; or, unspecified server occured."
+            "example": "UUID is either missing or invalid; or, unspecified server occured.",
+            "description": "A more in-depth description of the issue, including parameters and/or error text when available."
           }
         }
       },
       "Error404": {
+        "description": "Not found.",
         "type": "object",
         "properties": {
           "title": {
@@ -568,22 +731,218 @@
           "details": {
             "type": "string",
             "example": "MediaWiki Cargo request succeeded by nothing was returned for the parameters: {}",
-            "description": "UUID is either missing or invalid; or, unspecified server occured."
+            "description": "A more in-depth description of the issue, including parameters and/or error text when available."
           }
         }
       },
       "Error500": {
+        "description": "Internal server error.",
         "type": "object",
         "properties": {
           "title": {
             "type": "string",
-            "example": "Failed to identify the provided month filter.",
+            "example": "API experienced a fatal error.",
             "description": "A brief title describing the error."
           },
           "details": {
             "type": "string",
-            "example": "Provided month filter currentd was not recognized as a valid month.",
+            "example": "Details unknown.",
             "description": "A more in-depth description of the issue, including parameters and/or error text when available."
+          }
+        }
+      },
+      "Villager": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "example": "https://nookipedia.com/wiki/Ribbot",
+            "description": "Link to the respective Nookipedia article."
+          },
+          "name": {
+            "type": "string",
+            "example": "Ribbot",
+            "description": "Name of the villager."
+          },
+          "id": {
+            "type": "string",
+            "example": "flg01",
+            "description": "The game's internal identifier for the villager. Not all villagers have IDs; villagers who appeared in any game including or after Wild World have a consistent ID between games."
+          },
+          "image": {
+            "type": "string",
+            "example": "https://dodo.ac/np/images/9/94/Ribbot_NH.png",
+            "description": "Image of the fish. dodo.ac is Nookipedia's CDN server."
+          },
+          "species": {
+            "type": "string",
+            "example": "Frog",
+            "description": "The villager's species.",
+            "enum": [
+              "Alligator",
+              "Anteater",
+              "Bear",
+              "Bird",
+              "Bull",
+              "Cat",
+              "Cub",
+              "Chicken",
+              "Cow",
+              "Deer",
+              "Dog",
+              "Duck",
+              "Eagle",
+              "Elephant",
+              "Frog",
+              "Goat",
+              "Gorilla",
+              "Hamster",
+              "Hippo",
+              "Horse",
+              "Koala",
+              "Kangaroo",
+              "Lion",
+              "Monkey",
+              "Mouse",
+              "Octopus",
+              "Ostrich",
+              "Penguin",
+              "Pig",
+              "Rabbit",
+              "Rhino",
+              "Sheep",
+              "Squirrel",
+              "Tiger",
+              "Wolf"
+            ]
+          },
+          "personality": {
+            "type": "string",
+            "example": "Jock",
+            "description": "The villager's personality. Note that there are no official in-game personality names; these are names that are commonly used by the community. In the case of Sisterly, other common names include Big Sister and Uchi.",
+            "enum": [
+              "Cranky",
+              "Jock",
+              "Lazy",
+              "Normal",
+              "Peppy",
+              "Sisterly",
+              "Smug",
+              "Snooty"
+            ]
+          },
+          "gender": {
+            "type": "string",
+            "example": "Male",
+            "description": "Gender of the villager. In Animal Crossing, only male and female are used.",
+            "enum": [
+              "Male",
+              "Female"
+            ]
+          },
+          "birthday": {
+            "type": "string",
+            "example": "February 13",
+            "description": "Birthday of the villager in 'Month Day' form."
+          },
+          "sign": {
+            "type": "string",
+            "example": "Aquarius",
+            "description": "The villager's astrological star sign.",
+            "enum": [
+              "Aries",
+              "Taurus",
+              "Gemini",
+              "Cancer",
+              "Leo",
+              "Virgo",
+              "Libra",
+              "Scorpio",
+              "Sagittarius",
+              "Capricorn",
+              "Aquarius",
+              "Pisces"
+            ]
+          },
+          "quote": {
+            "type": "string",
+            "example": "Never rest, never rust.",
+            "description": "The villager's quote as it appears on the back of their in-game portrait item. This will be the quote from the latest game (i.e. if the villager had varying quotes between Wild World and New Horizons, this will be the New Horizons quote)."
+          },
+          "phrase": {
+            "type": "string",
+            "example": "zzrrbbit",
+            "description": "The villager's default phrase they use throughout conversation. This will be the phrase from the latest game (i.e. if the villager had varying phrases between Wild World and New Horizons, this will be the New Horizons quote)."
+          },
+          "prev_phrases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "toady"
+            ],
+            "description": "Any phrases used in previous Animal Crossing installations. May be empty."
+          },
+          "clothes": {
+            "type": "string",
+            "example": "zzrrbbit",
+            "description": "The villager's default clothing. This will be the clothing from the latest game (i.e. if the villager had varying phrases between Wild World and New Horizons, this will be the New Horizons clothing)."
+          },
+          "islander": {
+            "type": "boolean",
+            "example": false,
+            "description": "Whether the villager was an island in Animal Crossing for GameCube. Only a small number of villagers (36) were islanders."
+          },
+          "debut": {
+            "type": "string",
+            "example": "DNM",
+            "description": "The first Animal Crossing game the villager appeared in. DNM is Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); AC is Animal Crossing for GameCube; E_PLUS is Doubutsu no Mori e+ for GameCube (expanded port of AC, Japan-exclusive); WW is Wild World for the DS; CF is City Folk for Wii; NL is New Leaf for 3DS; WA is Welcome amiibo, the New Leaf expansion; NH is New Horizons for Switch; FILM is the Doubutsu no Mori Japan-exclusive film; HHD is Happy Home Designer for the Wii; and PC is Pocket Camp for mobile.",
+            "enum": [
+              "DNM",
+              "AC",
+              "E_PLUS",
+              "WW",
+              "CF",
+              "NL",
+              "WA",
+              "NH",
+              "FILM",
+              "HHD",
+              "PC"
+            ]
+          },
+          "appearances": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "DNM",
+              "AC",
+              "E_PLUS",
+              "WW",
+              "CF",
+              "NL",
+              "WA",
+              "NH",
+              "HHD",
+              "PC"
+            ],
+            "description": "List of official media villager appeared in. DNM is Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); AC is Animal Crossing for GameCube; E_PLUS is Doubutsu no Mori e+ for GameCube (expanded port of AC, Japan-exclusive); WW is Wild World for the DS; CF is City Folk for Wii; NL is New Leaf for 3DS; WA is Welcome amiibo, the New Leaf expansion; NH is New Horizons for Switch; FILM is the Doubutsu no Mori Japan-exclusive film; HHD is Happy Home Designer for the Wii; and PC is Pocket Camp for mobile.",
+            "enum": [
+              "DNM",
+              "AC",
+              "E_PLUS",
+              "WW",
+              "CF",
+              "NL",
+              "WA",
+              "NH",
+              "FILM",
+              "HHD",
+              "PC"
+            ]
           }
         }
       },

--- a/static/doc.json
+++ b/static/doc.json
@@ -121,7 +121,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A JSON array of villagers",
+            "description": "A JSON array of villagers.",
             "content": {
               "application/json": {
                 "schema": {
@@ -275,7 +275,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A JSON array of villagers",
+            "description": "A JSON object describing the villager.",
             "content": {
               "application/json": {
                 "schema": {
@@ -293,6 +293,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Error401"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Could not find the specified villager.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error404"
                 }
               }
             }
@@ -364,7 +374,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A JSON array of fish",
+            "description": "A JSON array of fish.",
             "content": {
               "application/json": {
                 "schema": {
@@ -540,7 +550,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A JSON array of bug",
+            "description": "A JSON array of bugs.",
             "content": {
               "application/json": {
                 "schema": {
@@ -716,7 +726,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A JSON array of sea creature",
+            "description": "A JSON array of sea creatures.",
             "content": {
               "application/json": {
                 "schema": {

--- a/static/doc.json
+++ b/static/doc.json
@@ -14,7 +14,7 @@
     "/villager": {
       "get": {
         "summary": "Villagers",
-        "description": "All villagers from the entire Animal Crossing series, with the option to filter by species and/or personality. Note that villagers only includes the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",
+        "description": "This endpoint retrieves villagers from the entire Animal Crossing series, with the option to filter by species and/or TODO personality. Note that villagers only includes the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",
         "parameters": [
           {
             "in": "header",
@@ -102,6 +102,31 @@
           },
           {
             "in": "query",
+            "name": "game",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "DNM",
+                  "AC",
+                  "E_PLUS",
+                  "WW",
+                  "CF",
+                  "NL",
+                  "WA",
+                  "NH",
+                  "FILM",
+                  "HHD",
+                  "PC"
+                ]
+              }
+            },
+            "description": "Retrieve villagers that appear in all listed games. If you wanted only villagers that appear in both *New Horizons* and *Pocket Camp*, you would send in `game=nh&game=pc`."
+          },
+          {
+            "in": "query",
             "name": "birthmonth",
             "required": false,
             "schema": {
@@ -120,12 +145,12 @@
           },
           {
             "in": "query",
-            "name": "includenhdetails",
+            "name": "nhdetails",
             "required": false,
             "schema": {
               "type": "string"
             },
-            "description": "Specify if you would like to also receive the `nh_details` object that contains New Horizons details about the villager."
+            "description": "When set to `true`, an `nh_details` object will be included that contains New Horizons details about the villager."
           },
           {
             "in": "query",

--- a/static/doc.json
+++ b/static/doc.json
@@ -279,10 +279,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Villager"
-                  }
+                  "$ref": "#/components/schemas/Villager"
                 }
               }
             }

--- a/static/doc.json
+++ b/static/doc.json
@@ -14,7 +14,7 @@
     "/villager": {
       "get": {
         "summary": "Villagers",
-        "description": "This endpoint retrieves villager information from the entire Animal Crossing series, with the option to filter by species, personality, game, and/or birthday. Note that villagers only includes the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",
+        "description": "This endpoint retrieves villager information from the entire Animal Crossing series, with the option to filter by species, personality, game, and/or birthday. Filters use the AND operator (e.g. asking for villagers who have species `frog` and personality `smug` will return all smug frogs). Note that villagers only include the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",
         "parameters": [
           {
             "in": "header",
@@ -123,7 +123,7 @@
                 ]
               }
             },
-            "description": "Retrieve villagers that appear in all listed games. If you wanted only villagers that appear in both *New Horizons* and *Pocket Camp*, you would send in `game=nh&game=pc`."
+            "description": "Retrieve villagers that appear in all listed games. If you want only villagers that appear in both *New Horizons* and *Pocket Camp*, you would send in `?game=nh&game=pc`."
           },
           {
             "in": "query",
@@ -168,7 +168,7 @@
             "schema": {
               "type": "integer"
             },
-            "description": "Specify the desired width of returned image URLs. When unspecified, the linked image(s) returned by the API will be full-resolution. Note that images can only be reduced in size; specifying a width greater than than the maximum size will return the default full-size image URL. This parameter is generally not recommended unless you absolutely need it, as each returned thumbnail link with a custom size requires an additional network call, which can result in a long response time if calling this endpoint in between cache refreshes."
+            "description": "Specify the desired width of returned image URLs. When unspecified, the linked image(s) returned by the API will be full-resolution. Note that images can only be reduced in size; specifying a width greater than than the maximum size will return the default full-size image URL. When asking for a large list of villagers, this parameter is generally not recommended as the generation of each custom-sized thumbnail requires an additional network call to generate, which can result in a very long response time."
           }
         ],
         "responses": {

--- a/static/doc.json
+++ b/static/doc.json
@@ -14,7 +14,7 @@
     "/villager": {
       "get": {
         "summary": "All villagers",
-        "description": "All villagers from the entire Animal Crossing series. Note that villagers only includes the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",
+        "description": "All villagers from the entire Animal Crossing series, with the option to filter by species and/or personality. Note that villagers only includes the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",
         "parameters": [
           {
             "in": "header",
@@ -98,7 +98,7 @@
                 "sisterly"
               ]
             },
-            "description": "Retrieve villagers with a certain personality. For 'sisterly', that the community often also calls it 'uchi' or 'big sister'."
+            "description": "Retrieve villagers with a certain personality. For 'sisterly', note that the community often also calls it 'uchi' or 'big sister'."
           },
           {
             "in": "query",
@@ -107,7 +107,161 @@
             "schema": {
               "type": "string"
             },
-            "description": "When set to `true`, only fish names are returned. Instead of an array of objects with all details, the return will be an array of strings. This is particularly useful when used with the `month` filter, for users who want just a list of fish in a given month but not all their respective details."
+            "description": "When set to `true`, only villager names are returned. Instead of an array of objects with all details, the return will be an array of strings."
+          },
+          {
+            "in": "query",
+            "name": "thumbsize",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Specify the desired width of returned image URLs. When unspecified, the linked image(s) returned by the API will be full-resolution. Note that images can only be reduced in size; specifying a width greater than than the maximum size will return the default full-size image URL. This parameter is generally not recommended unless you absolutely need it, as each returned thumbnail link with a custom size requires an additional network call, which can result in a long response time if calling this endpoint in between cache refreshes."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A JSON array of villagers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Villager"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Failed to authenticate user from `X-API-KEY`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error401"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was an error fetching the requested data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error500"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/villager/{villager}": {
+      "get": {
+        "summary": "Single villager",
+        "description": "Retrieve information about a specific villager. Note that villagers only includes the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "villager",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name of the villager you wish to retrieve information about."
+          },
+          {
+            "in": "header",
+            "name": "X-API-KEY",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Your UUID secret key, granted to you by the Nookipedia team. Required for accessing the API."
+          },
+          {
+            "in": "header",
+            "name": "Accept-Version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
+          },
+          {
+            "in": "query",
+            "name": "species",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "alligator",
+                "anteater",
+                "bear",
+                "bird",
+                "bull",
+                "cat",
+                "cub",
+                "chicken",
+                "cow",
+                "deer",
+                "dog",
+                "duck",
+                "eagle",
+                "elephant",
+                "frog",
+                "goat",
+                "gorilla",
+                "hamster",
+                "hippo",
+                "horse",
+                "koala",
+                "kangaroo",
+                "lion",
+                "monkey",
+                "mouse",
+                "octopus",
+                "ostrich",
+                "penguin",
+                "pig",
+                "rabbit",
+                "rhino",
+                "sheep",
+                "squirrel",
+                "tiger",
+                "wolf"
+              ]
+            },
+            "description": "Retrieve villagers of a certain species."
+          },
+          {
+            "in": "query",
+            "name": "personality",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "lazy",
+                "jock",
+                "cranky",
+                "smug",
+                "normal",
+                "peppy",
+                "snooty",
+                "sisterly"
+              ]
+            },
+            "description": "Retrieve villagers with a certain personality. For 'sisterly', note that the community often also calls it 'uchi' or 'big sister'."
+          },
+          {
+            "in": "query",
+            "name": "excludedetails",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "When set to `true`, only villager names are returned. Instead of an array of objects with all details, the return will be an array of strings."
           },
           {
             "in": "query",
@@ -248,7 +402,7 @@
     "/nh/fish/{fish}": {
       "get": {
         "summary": "Single New Horizons fish",
-        "description": "Optional extended description in CommonMark or HTML.",
+        "description": "Retrieve information about a specific fish in *Animal Crossing: New Horizons*.",
         "parameters": [
           {
             "in": "path",
@@ -424,7 +578,7 @@
     "/nh/bugs/{bug}": {
       "get": {
         "summary": "Single New Horizons bug",
-        "description": "Optional extended description in CommonMark or HTML.",
+        "description": "Retrieve information about a specific bug in *Animal Crossing: New Horizons*.",
         "parameters": [
           {
             "in": "path",
@@ -600,7 +754,7 @@
     "/nh/sea/{sea_creature}": {
       "get": {
         "summary": "Single NH sea creature",
-        "description": "Optional extended description in CommonMark or HTML.",
+        "description": "Retrieve information about a specific sea creature in *Animal Crossing: New Horizons*.",
         "parameters": [
           {
             "in": "path",
@@ -819,7 +973,7 @@
           "personality": {
             "type": "string",
             "example": "Jock",
-            "description": "The villager's personality. Note that there are no official in-game personality names; these are names that are commonly used by the community. In the case of Sisterly, other common names include Big Sister and Uchi.",
+            "description": "The villager's personality. Note that there are no official in-game personality names; these are names that are commonly used by the community. In the case of 'sisterly', other common names include 'big sis' and 'uchi'.",
             "enum": [
               "Cranky",
               "Jock",

--- a/static/doc.json
+++ b/static/doc.json
@@ -929,7 +929,7 @@
           "quote": {
             "type": "string",
             "example": "Never rest, never rust.",
-            "description": "The villager's quote as it appears on the back of their in-game portrait item. This will be the quote from the latest game (i.e. if the villager had varying quotes between Wild World and New Horizons, this will be the New Horizons quote)."
+            "description": "The villager's quote as it appears on the back of their in-game portrait item. This will be the quote from the latest game (i.e. if the villager had varying quotes between Wild World and New Horizons, this will be the New Horizons quote). For villagers from older games that do not have a quote, this field will be an empty string."
           },
           "phrase": {
             "type": "string",

--- a/static/doc.json
+++ b/static/doc.json
@@ -930,10 +930,10 @@
             "example": "flg01",
             "description": "The game's internal identifier for the villager. Not all villagers have IDs; villagers who appeared in any game including or after Wild World have a consistent ID between games."
           },
-          "image": {
+          "image_url": {
             "type": "string",
             "example": "https://dodo.ac/np/images/9/94/Ribbot_NH.png",
-            "description": "Image of the fish. dodo.ac is Nookipedia's CDN server."
+            "description": "Image of the villager from the latest game the villager appeared in. dodo.ac is Nookipedia's CDN server."
           },
           "species": {
             "type": "string",
@@ -1045,9 +1045,9 @@
             ],
             "description": "Any phrases used in previous Animal Crossing installations. May be empty."
           },
-          "clothes": {
+          "clothing": {
             "type": "string",
-            "example": "zzrrbbit",
+            "example": "Simple Parka",
             "description": "The villager's default clothing. This will be the clothing from the latest game (i.e. if the villager had varying phrases between Wild World and New Horizons, this will be the New Horizons clothing)."
           },
           "islander": {
@@ -1076,7 +1076,20 @@
           "appearances": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "DNM",
+                "AC",
+                "E_PLUS",
+                "WW",
+                "CF",
+                "NL",
+                "WA",
+                "NH",
+                "FILM",
+                "HHD",
+                "PC"
+              ]
             },
             "example": [
               "DNM",
@@ -1090,20 +1103,121 @@
               "HHD",
               "PC"
             ],
-            "description": "List of official media villager appeared in. DNM is Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); AC is Animal Crossing for GameCube; E_PLUS is Doubutsu no Mori e+ for GameCube (expanded port of AC, Japan-exclusive); WW is Wild World for the DS; CF is City Folk for Wii; NL is New Leaf for 3DS; WA is Welcome amiibo, the New Leaf expansion; NH is New Horizons for Switch; FILM is the Doubutsu no Mori Japan-exclusive film; HHD is Happy Home Designer for the Wii; and PC is Pocket Camp for mobile.",
-            "enum": [
-              "DNM",
-              "AC",
-              "E_PLUS",
-              "WW",
-              "CF",
-              "NL",
-              "WA",
-              "NH",
-              "FILM",
-              "HHD",
-              "PC"
-            ]
+            "description": "List of official media villager appeared in. DNM is Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); AC is Animal Crossing for GameCube; E_PLUS is Doubutsu no Mori e+ for GameCube (expanded port of AC, Japan-exclusive); WW is Wild World for the DS; CF is City Folk for Wii; NL is New Leaf for 3DS; WA is Welcome amiibo, the New Leaf expansion; NH is New Horizons for Switch; FILM is the Doubutsu no Mori Japan-exclusive film; HHD is Happy Home Designer for the Wii; and PC is Pocket Camp for mobile."
+          },
+          "nh_details": {
+            "type": "object",
+            "properties": {
+              "image_url": {
+                "type": "string",
+                "example": "https://dodo.ac/np/images/9/94/Ribbot_NH.png",
+                "description": "Image of the villager from New Horizons."
+              },
+              "photo_url": {
+                "type": "string",
+                "example": "https://dodo.ac/np/images/0/03/RibbotPicACNH.png",
+                "description": "The villager's photo, received by the player after attaining a certain friendship level."
+              },
+              "icon_url": {
+                "type": "string",
+                "example": "https://dodo.ac/np/images/8/87/Ribbot_NH_Villager_Icon.png",
+                "description": "The villager's icon of their head."
+              },
+              "quote": {
+                "type": "string",
+                "example": "Never rest, never rust.",
+                "description": "The villager's quote, as found on the bac of their in-game photo."
+              },
+              "sub-personality": {
+                "type": "string",
+                "example": "B",
+                "description": "Each personality in New Horizons has two sub-personalities, currently referred to as just A and B. The effect of a sub-personality is currently unknown.",
+                "enum": [
+                  "A",
+                  "B"
+                ]
+              },
+              "catchphrase": {
+                "type": "string",
+                "example": "zzrrbbit",
+                "description": "The default phrase a villager will use when speaking to the player."
+              },
+              "clothing": {
+                "type": "string",
+                "example": "Simple Parka",
+                "description": "The default clothing that the villager wears."
+              },
+              "clothing_variation": {
+                "type": "string",
+                "example": "Light Blue",
+                "description": "The variation of the clothing (usually a color)."
+              },
+              "fav_styles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "example": [
+                  "Simple",
+                  "Active"
+                ],
+                "description": "The villager's favorite clothing styles."
+              },
+              "fav_colors": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "example": [
+                  "Blue",
+                  "Aqua"
+                ],
+                "description": "The villager's favorite colors (giving the villager a gift with one of their favorite colors increases friendship points)."
+              },
+              "hobby": {
+                "type": "string",
+                "example": "Fitness",
+                "description": "The villager's primary hobby, which determines most of the activities they will do around the island (e.g. education villagers will frequently read books and visit the museum). Learn more at https://nookipedia.com/wiki/Hobbies",
+                "enum": [
+                  "Education",
+                  "Fashion",
+                  "Fitness",
+                  "Music",
+                  "Nature",
+                  "Play"
+                ]
+              },
+              "house_interior_url": {
+                "type": "string",
+                "example": "https://dodo.ac/np/images/8/86/House_of_Ribbot_NH.png",
+                "description": "A screenshot of the villager's house interior."
+              },
+              "house_exterior_url": {
+                "type": "string",
+                "example": "https://dodo.ac/np/images/4/42/House_of_Ribbot_NH_Model.png",
+                "description": "A rendered model of the villager's house exterior. Note that this is not an official Nintendo asset, but a render based of the in-game model."
+              },
+              "house_wallpaper": {
+                "type": "string",
+                "example": "Circuit-Board Wall",
+                "description": "The wallpaper in the villager's house."
+              },
+              "house_flooring": {
+                "type": "string",
+                "example": "Future-Tech Flooring",
+                "description": "The flooring in the villager's house."
+              },
+              "house_music": {
+                "type": "string",
+                "example": "K.K. Technopop",
+                "description": "The music in the villager's house."
+              },
+              "house_music_note": {
+                "type": "string",
+                "example": "",
+                "description": "Any notes about the villager's music. This is usually \"Does not contain a stereo initially\", meaning that the villager's house will not play music unless provided with a stereo."
+              }
+            }
           }
         }
       },
@@ -1125,7 +1239,7 @@
             "example": "27",
             "description": "In-game fish number, marking position in the Critterpedia."
           },
-          "image": {
+          "image_url": {
             "type": "string",
             "example": "https://dodo.ac/np/images/d/db/Cherry_Salmon_NH_Icon.png",
             "description": "Image of the fish. dodo.ac is Nookipedia's CDN server."
@@ -1263,7 +1377,7 @@
             "example": "19",
             "description": "In-game bug number, marking position in the Critterpedia."
           },
-          "image": {
+          "image_url": {
             "type": "string",
             "example": "https://dodo.ac/np/images/3/37/Grasshopper_NH_Icon.png",
             "description": "Image of the bug. dodo.ac is Nookipedia's CDN server."
@@ -1372,7 +1486,7 @@
             "example": "20",
             "description": "In-game sea creature number, marking position in the Critterpedia."
           },
-          "image": {
+          "image_url": {
             "type": "string",
             "example": "https://dodo.ac/np/images/5/58/Octopus_NH_Icon.png",
             "description": "Image of the sea creature. dodo.ac is Nookipedia's CDN server."

--- a/static/doc.json
+++ b/static/doc.json
@@ -671,7 +671,7 @@
     },
     "/nh/sea": {
       "get": {
-        "summary": "All NH sea creatures",
+        "summary": "All New Horizons sea creatures",
         "description": "Get a list of all sea creatures and their details in *Animal Crossing: New Horizons*. Note that while cached, this endpoint will be very responsive; however, hitting the endpoint in between cache refreshes can result in a response time of 5 to 15 seconds.",
         "parameters": [
           {
@@ -760,7 +760,7 @@
     },
     "/nh/sea/{sea_creature}": {
       "get": {
-        "summary": "Single NH sea creature",
+        "summary": "Single New Horizons sea creature",
         "description": "Retrieve information about a specific sea creature in *Animal Crossing: New Horizons*.",
         "parameters": [
           {

--- a/static/doc.json
+++ b/static/doc.json
@@ -102,6 +102,33 @@
           },
           {
             "in": "query",
+            "name": "birthmonth",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Retrieve villagers born in a specific month. Value may be the month's name (`jan`, `january`) or the integer representing the month (`01`, `1`)."
+          },
+          {
+            "in": "query",
+            "name": "birthday",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Use with `birthmonth` to get villager(s) born on a specific day. Value should be an int, 1 through 31."
+          },
+          {
+            "in": "query",
+            "name": "includenhdetails",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Specify if you would like to also receive the `nh_details` object that contains New Horizons details about the villager."
+          },
+          {
+            "in": "query",
             "name": "excludedetails",
             "required": false,
             "schema": {
@@ -197,7 +224,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Retrive only the fish that are available in a specific month. Value may be the month's name (`jan`, `january`), the integer representing the number (`01`, `1`), or `current` for the current month. When `current` is specified, the return body will be an object with two arrays inside, one called `north` and the other `south` containing the fish available in each respective hemisphere. Note that the current month is calculated based off the API server's time, so it may be slightly off for you at the beginning or end of the month."
+            "description": "Retrive only the fish that are available in a specific month. Value may be the month's name (`jan`, `january`), the integer representing the month (`01`, `1`), or `current` for the current month. When `current` is specified, the return body will be an object with two arrays inside, one called `north` and the other `south` containing the fish available in each respective hemisphere. Note that the current month is calculated based off the API server's time, so it may be slightly off for you at the beginning or end of the month."
           },
           {
             "in": "query",
@@ -373,7 +400,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Retrive only the bug that are available in a specific month. Value may be the month's name (`jan`, `january`), the integer representing the number (`01`, `1`), or `current` for the current month. When `current` is specified, the return body will be an object with two arrays inside, one called `north` and the other `south` containing the bug available in each respective hemisphere. Note that the current month is calculated based off the API server's time, so it may be slightly off for you at the beginning or end of the month."
+            "description": "Retrive only the bug that are available in a specific month. Value may be the month's name (`jan`, `january`), the integer representing the month (`01`, `1`), or `current` for the current month. When `current` is specified, the return body will be an object with two arrays inside, one called `north` and the other `south` containing the bug available in each respective hemisphere. Note that the current month is calculated based off the API server's time, so it may be slightly off for you at the beginning or end of the month."
           },
           {
             "in": "query",
@@ -549,7 +576,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Retrive only the sea creature that are available in a specific month. Value may be the month's name (`jan`, `january`), the integer representing the number (`01`, `1`), or `current` for the current month. When `current` is specified, the return body will be an object with two arrays inside, one called `north` and the other `south` containing the sea creature available in each respective hemisphere. Note that the current month is calculated based off the API server's time, so it may be slightly off for you at the beginning or end of the month."
+            "description": "Retrive only the sea creature that are available in a specific month. Value may be the month's name (`jan`, `january`), the integer representing the month (`01`, `1`), or `current` for the current month. When `current` is specified, the return body will be an object with two arrays inside, one called `north` and the other `south` containing the sea creature available in each respective hemisphere. Note that the current month is calculated based off the API server's time, so it may be slightly off for you at the beginning or end of the month."
           },
           {
             "in": "query",

--- a/static/doc.json
+++ b/static/doc.json
@@ -959,7 +959,7 @@
           "debut": {
             "type": "string",
             "example": "DNM",
-            "description": "The first Animal Crossing game the villager appeared in. `DNM` is Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); `AC` is Animal Crossing for GameCube; `E_PLUS` is Doubutsu no Mori e+ for GameCube (expanded port of AC, Japan-exclusive); `WW` is Wild World for the DS; `CF` is City Folk for Wii; `NL` is New Leaf for 3DS; `WA` is Welcome amiibo, the New Leaf expansion; NH is New Horizons for Switch; `FILM` is the Doubutsu no Mori Japan-exclusive film; `HHD` is Happy Home Designer for the Wii; and `PC` is Pocket Camp for mobile.",
+            "description": "The first Animal Crossing game the villager appeared in. `DNM` is Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); `AC` is Animal Crossing for GameCube; `E_PLUS` is Doubutsu no Mori e+ for GameCube (expanded port of AC, Japan-exclusive); `WW` is Wild World for the DS; `CF` is City Folk for Wii; `NL` is New Leaf for 3DS; `WA` is Welcome amiibo, the New Leaf expansion; `NH` is New Horizons for Switch; `FILM` is the Doubutsu no Mori Japan-exclusive film; `HHD` is Happy Home Designer for the Wii; and `PC` is Pocket Camp for mobile.",
             "enum": [
               "DNM",
               "AC",
@@ -1004,7 +1004,7 @@
               "HHD",
               "PC"
             ],
-            "description": "List of official media villager appeared in. `DNM` is Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); `AC` is Animal Crossing for GameCube; `E_PLUS` is Doubutsu no Mori e+ for GameCube (expanded port of AC, Japan-exclusive); `WW` is Wild World for the DS; `CF` is City Folk for Wii; `NL` is New Leaf for 3DS; `WA` is Welcome amiibo, the New Leaf expansion; NH is New Horizons for Switch; `FILM` is the Doubutsu no Mori Japan-exclusive film; `HHD` is Happy Home Designer for the Wii; and `PC` is Pocket Camp for mobile."
+            "description": "List of official media villager appeared in. `DNM` is Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); `AC` is Animal Crossing for GameCube; `E_PLUS` is Doubutsu no Mori e+ for GameCube (expanded port of AC, Japan-exclusive); `WW` is Wild World for the DS; `CF` is City Folk for Wii; `NL` is New Leaf for 3DS; `WA` is Welcome amiibo, the New Leaf expansion; `NH` is New Horizons for Switch; `FILM` is the Doubutsu no Mori Japan-exclusive film; `HHD` is Happy Home Designer for the Wii; and `PC` is Pocket Camp for mobile."
           },
           "nh_details": {
             "type": "object",

--- a/static/doc.json
+++ b/static/doc.json
@@ -1018,17 +1018,17 @@
               "photo_url": {
                 "type": "string",
                 "example": "https://dodo.ac/np/images/0/03/RibbotPicACNH.png",
-                "description": "The villager's photo, received by the player after attaining a certain friendship level."
+                "description": "The villager's photo, received by the player after attaining a certain friendship level. See https://nookipedia.com/wiki/Category:New_Horizons_pictures for full list."
               },
               "icon_url": {
                 "type": "string",
                 "example": "https://dodo.ac/np/images/8/87/Ribbot_NH_Villager_Icon.png",
-                "description": "The villager's icon of their head."
+                "description": "The villager's icon of their head. See https://nookipedia.com/wiki/Category:New_Horizons_character_icons for full list."
               },
               "quote": {
                 "type": "string",
                 "example": "Never rest, never rust.",
-                "description": "The villager's quote, as found on the bac of their in-game photo."
+                "description": "The villager's quote, as found on the back of their in-game photo."
               },
               "sub-personality": {
                 "type": "string",
@@ -1117,7 +1117,7 @@
               "house_music_note": {
                 "type": "string",
                 "example": "",
-                "description": "Any notes about the villager's music. This is usually \"Does not contain a stereo initially\", meaning that the villager's house will not play music unless provided with a stereo."
+                "description": "Any notes about the villager's music. If populated, this is usually \"Does not contain a stereo initially\", meaning that the villager's house will not play music unless provided with a stereo."
               }
             }
           }

--- a/static/doc.json
+++ b/static/doc.json
@@ -14,7 +14,7 @@
     "/villager": {
       "get": {
         "summary": "Villagers",
-        "description": "This endpoint retrieves villagers from the entire Animal Crossing series, with the option to filter by species and/or TODO personality. Note that villagers only includes the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",
+        "description": "This endpoint retrieves villager information from the entire Animal Crossing series, with the option to filter by species, personality, game, and/or birthday. Note that villagers only includes the animals that act as residents. Special characters, such as Tom Nook and Isabelle, are not accessed through this endpoint.",
         "parameters": [
           {
             "in": "header",

--- a/static/doc.json
+++ b/static/doc.json
@@ -150,7 +150,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "When set to `true`, an `nh_details` object will be included that contains New Horizons details about the villager."
+            "description": "When set to `true`, an `nh_details` object will be included that contains New Horizons details about the villager. If the villager does not appear in *New Horizons*, the returned `nh_details` field will be set to null."
           },
           {
             "in": "query",
@@ -190,7 +190,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Error401"
+                  "$ref": "#/components/schemas/Error400"
                 }
               }
             }
@@ -905,7 +905,7 @@
           "birthday": {
             "type": "string",
             "example": "February 13",
-            "description": "Birthday of the villager in 'Month Day' form."
+            "description": "Birthday of the villager in 'Month Day' form. Note that villager birthdays were not introduced until *Wild World*. For villagers who didn't appear in *Wild World* or any later games, this field will be an empty string."
           },
           "sign": {
             "type": "string",
@@ -959,7 +959,7 @@
           "debut": {
             "type": "string",
             "example": "DNM",
-            "description": "The first Animal Crossing game the villager appeared in. DNM is Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); AC is Animal Crossing for GameCube; E_PLUS is Doubutsu no Mori e+ for GameCube (expanded port of AC, Japan-exclusive); WW is Wild World for the DS; CF is City Folk for Wii; NL is New Leaf for 3DS; WA is Welcome amiibo, the New Leaf expansion; NH is New Horizons for Switch; FILM is the Doubutsu no Mori Japan-exclusive film; HHD is Happy Home Designer for the Wii; and PC is Pocket Camp for mobile.",
+            "description": "The first Animal Crossing game the villager appeared in. `DNM` is Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); `AC` is Animal Crossing for GameCube; `E_PLUS` is Doubutsu no Mori e+ for GameCube (expanded port of AC, Japan-exclusive); `WW` is Wild World for the DS; `CF` is City Folk for Wii; `NL` is New Leaf for 3DS; `WA` is Welcome amiibo, the New Leaf expansion; NH is New Horizons for Switch; `FILM` is the Doubutsu no Mori Japan-exclusive film; `HHD` is Happy Home Designer for the Wii; and `PC` is Pocket Camp for mobile.",
             "enum": [
               "DNM",
               "AC",
@@ -1004,10 +1004,11 @@
               "HHD",
               "PC"
             ],
-            "description": "List of official media villager appeared in. DNM is Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); AC is Animal Crossing for GameCube; E_PLUS is Doubutsu no Mori e+ for GameCube (expanded port of AC, Japan-exclusive); WW is Wild World for the DS; CF is City Folk for Wii; NL is New Leaf for 3DS; WA is Welcome amiibo, the New Leaf expansion; NH is New Horizons for Switch; FILM is the Doubutsu no Mori Japan-exclusive film; HHD is Happy Home Designer for the Wii; and PC is Pocket Camp for mobile."
+            "description": "List of official media villager appeared in. `DNM` is Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); `AC` is Animal Crossing for GameCube; `E_PLUS` is Doubutsu no Mori e+ for GameCube (expanded port of AC, Japan-exclusive); `WW` is Wild World for the DS; `CF` is City Folk for Wii; `NL` is New Leaf for 3DS; `WA` is Welcome amiibo, the New Leaf expansion; NH is New Horizons for Switch; `FILM` is the Doubutsu no Mori Japan-exclusive film; `HHD` is Happy Home Designer for the Wii; and `PC` is Pocket Camp for mobile."
           },
           "nh_details": {
             "type": "object",
+            "description": "An object that holds villager data specific to *New Horizons*. If the villager does not appear in *New Horizons*, this field will be set to null.",
             "properties": {
               "image_url": {
                 "type": "string",

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -912,7 +912,7 @@ components:
             Animal Crossing for GameCube; `E_PLUS` is Doubutsu no Mori e+ for
             GameCube (expanded port of AC, Japan-exclusive); `WW` is Wild World
             for the DS; `CF` is City Folk for Wii; `NL` is New Leaf for 3DS;
-            `WA` is Welcome amiibo, the New Leaf expansion; NH is New Horizons
+            `WA` is Welcome amiibo, the New Leaf expansion; `NH` is New Horizons
             for Switch; `FILM` is the Doubutsu no Mori Japan-exclusive film;
             `HHD` is Happy Home Designer for the Wii; and `PC` is Pocket Camp
             for mobile.
@@ -961,9 +961,9 @@ components:
             for GameCube; `E_PLUS` is Doubutsu no Mori e+ for GameCube (expanded
             port of AC, Japan-exclusive); `WW` is Wild World for the DS; `CF` is
             City Folk for Wii; `NL` is New Leaf for 3DS; `WA` is Welcome amiibo,
-            the New Leaf expansion; NH is New Horizons for Switch; `FILM` is the
-            Doubutsu no Mori Japan-exclusive film; `HHD` is Happy Home Designer
-            for the Wii; and `PC` is Pocket Camp for mobile.
+            the New Leaf expansion; `NH` is New Horizons for Switch; `FILM` is
+            the Doubutsu no Mori Japan-exclusive film; `HHD` is Happy Home
+            Designer for the Wii; and `PC` is Pocket Camp for mobile.
         nh_details:
           type: object
           description: >-

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -113,6 +113,31 @@ paths:
             Retrieve villagers with a certain personality. For 'sisterly', note
             that the community often also calls it 'uchi' or 'big sister'.
         - in: query
+          name: birthmonth
+          required: false
+          schema:
+            type: string
+          description: >-
+            Retrieve villagers born in a specific month. Value may be the
+            month's name (`jan`, `january`) or the integer representing the
+            month (`01`, `1`).
+        - in: query
+          name: birthday
+          required: false
+          schema:
+            type: string
+          description: >-
+            Use with `birthmonth` to get villager(s) born on a specific day.
+            Value should be an int, 1 through 31.
+        - in: query
+          name: includenhdetails
+          required: false
+          schema:
+            type: string
+          description: >-
+            Specify if you would like to also receive the `nh_details` object
+            that contains New Horizons details about the villager.
+        - in: query
           name: excludedetails
           required: false
           schema:
@@ -199,7 +224,7 @@ paths:
           description: >-
             Retrive only the fish that are available in a specific month. Value
             may be the month's name (`jan`, `january`), the integer representing
-            the number (`01`, `1`), or `current` for the current month. When
+            the month (`01`, `1`), or `current` for the current month. When
             `current` is specified, the return body will be an object with two
             arrays inside, one called `north` and the other `south` containing
             the fish available in each respective hemisphere. Note that the
@@ -357,7 +382,7 @@ paths:
           description: >-
             Retrive only the bug that are available in a specific month. Value
             may be the month's name (`jan`, `january`), the integer representing
-            the number (`01`, `1`), or `current` for the current month. When
+            the month (`01`, `1`), or `current` for the current month. When
             `current` is specified, the return body will be an object with two
             arrays inside, one called `north` and the other `south` containing
             the bug available in each respective hemisphere. Note that the
@@ -515,7 +540,7 @@ paths:
           description: >-
             Retrive only the sea creature that are available in a specific
             month. Value may be the month's name (`jan`, `january`), the integer
-            representing the number (`01`, `1`), or `current` for the current
+            representing the month (`01`, `1`), or `current` for the current
             month. When `current` is specified, the return body will be an
             object with two arrays inside, one called `north` and the other
             `south` containing the sea creature available in each respective

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -278,9 +278,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Villager'
+                $ref: '#/components/schemas/Villager'
         '401':
           description: Failed to authenticate user from `X-API-KEY`.
           content:

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -8,22 +8,156 @@ info:
     spanning the entire *Animal Crossing* series, as well as information that is
     constantly updated and expanding as editors work on the wiki.<br><br>This
     API launched in July 2020 and is under active development. At the moment, we
-    currently have endpoints to retrieve information about *Animal Crossing: New
-    Horizons* bugs, fish, and sea creatures. Coming very soon is data on all
-    *Animal Crossing* villagers. In the horizon are endpoints for *New Horizons*
-    furniture and clothing, as well as critters from previous
-    games.<br><br>Access to the Nookipedia API requires obtaining a key. This is
-    so we can manage our scale and provide better support for our users. To
-    request access to the API, please fill out [this
+    currently have endpoints to retrieve information about *Animal Crossing*
+    villagers, as well as *Animal Crossing: New Horizons* bugs, fish, and sea
+    creatures. In the horizon are endpoints for *New Horizons* furniture and
+    clothing, as well as critters from previous games.<br><br>Access to the
+    Nookipedia API requires obtaining a key. This is so we can manage our scale
+    and provide better support for our users. To request access to the API,
+    please fill out [this
     form](https://forms.gle/wLwtXLerKhfDrRLY8).<br><br>This API is 'version 2'
     of our [original API](https://nookipedia.com/api/). While the previous API
     scraped information directly from the wiki, this new edition of the API
     pulls data from a structured and constrained database, resulting in
     higher-quality data, better searching, and support for filtering.
-  version: 1.0.1
+  version: 1.2.0
 servers:
   - url: 'https://api.nookipedia.com/'
 paths:
+  /villager:
+    get:
+      summary: All villagers
+      description: >-
+        All villagers from the entire Animal Crossing series. Note that
+        villagers only includes the animals that act as residents. Special
+        characters, such as Tom Nook and Isabelle, are not accessed through this
+        endpoint.
+      parameters:
+        - in: header
+          name: X-API-KEY
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: >-
+            Your UUID secret key, granted to you by the Nookipedia team.
+            Required for accessing the API.
+        - in: header
+          name: Accept-Version
+          required: true
+          schema:
+            type: string
+          description: >-
+            The version of the API you are calling, written as `1.0.0`. This is
+            specified as required as good practice, but it is not actually
+            enforced by the API. If you do not specify a version, you will be
+            served the latest version, which may eventually result in breaking
+            changes.
+        - in: query
+          name: species
+          required: false
+          schema:
+            type: string
+            enum:
+              - alligator
+              - anteater
+              - bear
+              - bird
+              - bull
+              - cat
+              - cub
+              - chicken
+              - cow
+              - deer
+              - dog
+              - duck
+              - eagle
+              - elephant
+              - frog
+              - goat
+              - gorilla
+              - hamster
+              - hippo
+              - horse
+              - koala
+              - kangaroo
+              - lion
+              - monkey
+              - mouse
+              - octopus
+              - ostrich
+              - penguin
+              - pig
+              - rabbit
+              - rhino
+              - sheep
+              - squirrel
+              - tiger
+              - wolf
+          description: Retrieve villagers of a certain species.
+        - in: query
+          name: personality
+          required: false
+          schema:
+            type: string
+            enum:
+              - lazy
+              - jock
+              - cranky
+              - smug
+              - normal
+              - peppy
+              - snooty
+              - sisterly
+          description: >-
+            Retrieve villagers with a certain personality. For 'sisterly', that
+            the community often also calls it 'uchi' or 'big sister'.
+        - in: query
+          name: excludedetails
+          required: false
+          schema:
+            type: string
+          description: >-
+            When set to `true`, only fish names are returned. Instead of an
+            array of objects with all details, the return will be an array of
+            strings. This is particularly useful when used with the `month`
+            filter, for users who want just a list of fish in a given month but
+            not all their respective details.
+        - in: query
+          name: thumbsize
+          required: false
+          schema:
+            type: integer
+          description: >-
+            Specify the desired width of returned image URLs. When unspecified,
+            the linked image(s) returned by the API will be full-resolution.
+            Note that images can only be reduced in size; specifying a width
+            greater than than the maximum size will return the default full-size
+            image URL. This parameter is generally not recommended unless you
+            absolutely need it, as each returned thumbnail link with a custom
+            size requires an additional network call, which can result in a long
+            response time if calling this endpoint in between cache refreshes.
+      responses:
+        '200':
+          description: A JSON array of villagers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Villager'
+        '401':
+          description: Failed to authenticate user from `X-API-KEY`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '500':
+          description: There was an error fetching the requested data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /nh/fish:
     get:
       summary: All New Horizons fish
@@ -48,9 +182,11 @@ paths:
           schema:
             type: string
           description: >-
-            The version of the API you are calling, written as `1.0.0`. This
-            header is required as good practice, but is not currently utilized
-            by the API as there is only one version at the moment.
+            The version of the API you are calling, written as `1.0.0`. This is
+            specified as required as good practice, but it is not actually
+            enforced by the API. If you do not specify a version, you will be
+            served the latest version, which may eventually result in breaking
+            changes.
         - in: query
           name: month
           required: false
@@ -137,9 +273,11 @@ paths:
           schema:
             type: string
           description: >-
-            The version of the API you are calling, written as `1.0.0`. This
-            header is required as good practice, but is not currently utilized
-            by the API as there is only one version at the moment.
+            The version of the API you are calling, written as `1.0.0`. This is
+            specified as required as good practice, but it is not actually
+            enforced by the API. If you do not specify a version, you will be
+            served the latest version, which may eventually result in breaking
+            changes.
         - in: query
           name: thumbsize
           required: false
@@ -200,9 +338,11 @@ paths:
           schema:
             type: string
           description: >-
-            The version of the API you are calling, written as `1.0.0`. This
-            header is required as good practice, but is not currently utilized
-            by the API as there is only one version at the moment.
+            The version of the API you are calling, written as `1.0.0`. This is
+            specified as required as good practice, but it is not actually
+            enforced by the API. If you do not specify a version, you will be
+            served the latest version, which may eventually result in breaking
+            changes.
         - in: query
           name: month
           required: false
@@ -289,9 +429,11 @@ paths:
           schema:
             type: string
           description: >-
-            The version of the API you are calling, written as `1.0.0`. This
-            header is required as good practice, but is not currently utilized
-            by the API as there is only one version at the moment.
+            The version of the API you are calling, written as `1.0.0`. This is
+            specified as required as good practice, but it is not actually
+            enforced by the API. If you do not specify a version, you will be
+            served the latest version, which may eventually result in breaking
+            changes.
         - in: query
           name: thumbsize
           required: false
@@ -352,9 +494,11 @@ paths:
           schema:
             type: string
           description: >-
-            The version of the API you are calling, written as `1.0.0`. This
-            header is required as good practice, but is not currently utilized
-            by the API as there is only one version at the moment.
+            The version of the API you are calling, written as `1.0.0`. This is
+            specified as required as good practice, but it is not actually
+            enforced by the API. If you do not specify a version, you will be
+            served the latest version, which may eventually result in breaking
+            changes.
         - in: query
           name: month
           required: false
@@ -442,9 +586,11 @@ paths:
           schema:
             type: string
           description: >-
-            The version of the API you are calling, written as `1.0.0`. This
-            header is required as good practice, but is not currently utilized
-            by the API as there is only one version at the moment.
+            The version of the API you are calling, written as `1.0.0`. This is
+            specified as required as good practice, but it is not actually
+            enforced by the API. If you do not specify a version, you will be
+            served the latest version, which may eventually result in breaking
+            changes.
         - in: query
           name: thumbsize
           required: false
@@ -483,7 +629,22 @@ paths:
                 $ref: '#/components/schemas/Error500'
 components:
   schemas:
+    Error400:
+      description: Bad request (often an invalid input).
+      type: object
+      properties:
+        title:
+          type: string
+          example: Failed to identify the provided month filter.
+          description: A brief title describing the error.
+        details:
+          type: string
+          example: Provided month filter jonuary was not recognized as a valid month.
+          description: >-
+            A more in-depth description of the issue, including parameters
+            and/or error text when available.
     Error401:
+      description: Unauthorized.
       type: object
       properties:
         title:
@@ -492,9 +653,12 @@ components:
           description: A brief title describing the error.
         details:
           type: string
-          example: Provided month filter currentd was not recognized as a valid month.
-          description: 'UUID is either missing or invalid; or, unspecified server occured.'
+          example: 'UUID is either missing or invalid; or, unspecified server occured.'
+          description: >-
+            A more in-depth description of the issue, including parameters
+            and/or error text when available.
     Error404:
+      description: Not found.
       type: object
       properties:
         title:
@@ -506,20 +670,230 @@ components:
           example: >-
             MediaWiki Cargo request succeeded by nothing was returned for the
             parameters: {}
-          description: 'UUID is either missing or invalid; or, unspecified server occured.'
+          description: >-
+            A more in-depth description of the issue, including parameters
+            and/or error text when available.
     Error500:
+      description: Internal server error.
       type: object
       properties:
         title:
           type: string
-          example: Failed to identify the provided month filter.
+          example: API experienced a fatal error.
           description: A brief title describing the error.
         details:
           type: string
-          example: Provided month filter currentd was not recognized as a valid month.
+          example: Details unknown.
           description: >-
             A more in-depth description of the issue, including parameters
             and/or error text when available.
+    Villager:
+      type: object
+      properties:
+        url:
+          type: string
+          example: 'https://nookipedia.com/wiki/Ribbot'
+          description: Link to the respective Nookipedia article.
+        name:
+          type: string
+          example: Ribbot
+          description: Name of the villager.
+        id:
+          type: string
+          example: flg01
+          description: >-
+            The game's internal identifier for the villager. Not all villagers
+            have IDs; villagers who appeared in any game including or after Wild
+            World have a consistent ID between games.
+        image:
+          type: string
+          example: 'https://dodo.ac/np/images/9/94/Ribbot_NH.png'
+          description: Image of the fish. dodo.ac is Nookipedia's CDN server.
+        species:
+          type: string
+          example: Frog
+          description: The villager's species.
+          enum:
+            - Alligator
+            - Anteater
+            - Bear
+            - Bird
+            - Bull
+            - Cat
+            - Cub
+            - Chicken
+            - Cow
+            - Deer
+            - Dog
+            - Duck
+            - Eagle
+            - Elephant
+            - Frog
+            - Goat
+            - Gorilla
+            - Hamster
+            - Hippo
+            - Horse
+            - Koala
+            - Kangaroo
+            - Lion
+            - Monkey
+            - Mouse
+            - Octopus
+            - Ostrich
+            - Penguin
+            - Pig
+            - Rabbit
+            - Rhino
+            - Sheep
+            - Squirrel
+            - Tiger
+            - Wolf
+        personality:
+          type: string
+          example: Jock
+          description: >-
+            The villager's personality. Note that there are no official in-game
+            personality names; these are names that are commonly used by the
+            community. In the case of Sisterly, other common names include Big
+            Sister and Uchi.
+          enum:
+            - Cranky
+            - Jock
+            - Lazy
+            - Normal
+            - Peppy
+            - Sisterly
+            - Smug
+            - Snooty
+        gender:
+          type: string
+          example: Male
+          description: >-
+            Gender of the villager. In Animal Crossing, only male and female are
+            used.
+          enum:
+            - Male
+            - Female
+        birthday:
+          type: string
+          example: February 13
+          description: Birthday of the villager in 'Month Day' form.
+        sign:
+          type: string
+          example: Aquarius
+          description: The villager's astrological star sign.
+          enum:
+            - Aries
+            - Taurus
+            - Gemini
+            - Cancer
+            - Leo
+            - Virgo
+            - Libra
+            - Scorpio
+            - Sagittarius
+            - Capricorn
+            - Aquarius
+            - Pisces
+        quote:
+          type: string
+          example: 'Never rest, never rust.'
+          description: >-
+            The villager's quote as it appears on the back of their in-game
+            portrait item. This will be the quote from the latest game (i.e. if
+            the villager had varying quotes between Wild World and New Horizons,
+            this will be the New Horizons quote).
+        phrase:
+          type: string
+          example: zzrrbbit
+          description: >-
+            The villager's default phrase they use throughout conversation. This
+            will be the phrase from the latest game (i.e. if the villager had
+            varying phrases between Wild World and New Horizons, this will be
+            the New Horizons quote).
+        prev_phrases:
+          type: array
+          items:
+            type: string
+          example:
+            - toady
+          description: >-
+            Any phrases used in previous Animal Crossing installations. May be
+            empty.
+        clothes:
+          type: string
+          example: zzrrbbit
+          description: >-
+            The villager's default clothing. This will be the clothing from the
+            latest game (i.e. if the villager had varying phrases between Wild
+            World and New Horizons, this will be the New Horizons clothing).
+        islander:
+          type: boolean
+          example: false
+          description: >-
+            Whether the villager was an island in Animal Crossing for GameCube.
+            Only a small number of villagers (36) were islanders.
+        debut:
+          type: string
+          example: DNM
+          description: >-
+            The first Animal Crossing game the villager appeared in. DNM is
+            Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); AC is Animal
+            Crossing for GameCube; E_PLUS is Doubutsu no Mori e+ for GameCube
+            (expanded port of AC, Japan-exclusive); WW is Wild World for the DS;
+            CF is City Folk for Wii; NL is New Leaf for 3DS; WA is Welcome
+            amiibo, the New Leaf expansion; NH is New Horizons for Switch; FILM
+            is the Doubutsu no Mori Japan-exclusive film; HHD is Happy Home
+            Designer for the Wii; and PC is Pocket Camp for mobile.
+          enum:
+            - DNM
+            - AC
+            - E_PLUS
+            - WW
+            - CF
+            - NL
+            - WA
+            - NH
+            - FILM
+            - HHD
+            - PC
+        appearances:
+          type: array
+          items:
+            type: string
+          example:
+            - DNM
+            - AC
+            - E_PLUS
+            - WW
+            - CF
+            - NL
+            - WA
+            - NH
+            - HHD
+            - PC
+          description: >-
+            List of official media villager appeared in. DNM is Doubutsu no Mori
+            for the Nintendo 64 (Japan-exclusive); AC is Animal Crossing for
+            GameCube; E_PLUS is Doubutsu no Mori e+ for GameCube (expanded port
+            of AC, Japan-exclusive); WW is Wild World for the DS; CF is City
+            Folk for Wii; NL is New Leaf for 3DS; WA is Welcome amiibo, the New
+            Leaf expansion; NH is New Horizons for Switch; FILM is the Doubutsu
+            no Mori Japan-exclusive film; HHD is Happy Home Designer for the
+            Wii; and PC is Pocket Camp for mobile.
+          enum:
+            - DNM
+            - AC
+            - E_PLUS
+            - WW
+            - CF
+            - NL
+            - WA
+            - NH
+            - FILM
+            - HHD
+            - PC
     NHFish:
       type: object
       properties:

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -850,10 +850,12 @@ components:
             The game's internal identifier for the villager. Not all villagers
             have IDs; villagers who appeared in any game including or after Wild
             World have a consistent ID between games.
-        image:
+        image_url:
           type: string
           example: 'https://dodo.ac/np/images/9/94/Ribbot_NH.png'
-          description: Image of the fish. dodo.ac is Nookipedia's CDN server.
+          description: >-
+            Image of the villager from the latest game the villager appeared in.
+            dodo.ac is Nookipedia's CDN server.
         species:
           type: string
           example: Frog
@@ -966,9 +968,9 @@ components:
           description: >-
             Any phrases used in previous Animal Crossing installations. May be
             empty.
-        clothes:
+        clothing:
           type: string
-          example: zzrrbbit
+          example: Simple Parka
           description: >-
             The villager's default clothing. This will be the clothing from the
             latest game (i.e. if the villager had varying phrases between Wild
@@ -1007,6 +1009,18 @@ components:
           type: array
           items:
             type: string
+            enum:
+              - DNM
+              - AC
+              - E_PLUS
+              - WW
+              - CF
+              - NL
+              - WA
+              - NH
+              - FILM
+              - HHD
+              - PC
           example:
             - DNM
             - AC
@@ -1027,18 +1041,116 @@ components:
             Leaf expansion; NH is New Horizons for Switch; FILM is the Doubutsu
             no Mori Japan-exclusive film; HHD is Happy Home Designer for the
             Wii; and PC is Pocket Camp for mobile.
-          enum:
-            - DNM
-            - AC
-            - E_PLUS
-            - WW
-            - CF
-            - NL
-            - WA
-            - NH
-            - FILM
-            - HHD
-            - PC
+        nh_details:
+          type: object
+          properties:
+            image_url:
+              type: string
+              example: 'https://dodo.ac/np/images/9/94/Ribbot_NH.png'
+              description: Image of the villager from New Horizons.
+            photo_url:
+              type: string
+              example: 'https://dodo.ac/np/images/0/03/RibbotPicACNH.png'
+              description: >-
+                The villager's photo, received by the player after attaining a
+                certain friendship level.
+            icon_url:
+              type: string
+              example: 'https://dodo.ac/np/images/8/87/Ribbot_NH_Villager_Icon.png'
+              description: The villager's icon of their head.
+            quote:
+              type: string
+              example: 'Never rest, never rust.'
+              description: >-
+                The villager's quote, as found on the bac of their in-game
+                photo.
+            sub-personality:
+              type: string
+              example: B
+              description: >-
+                Each personality in New Horizons has two sub-personalities,
+                currently referred to as just A and B. The effect of a
+                sub-personality is currently unknown.
+              enum:
+                - A
+                - B
+            catchphrase:
+              type: string
+              example: zzrrbbit
+              description: >-
+                The default phrase a villager will use when speaking to the
+                player.
+            clothing:
+              type: string
+              example: Simple Parka
+              description: The default clothing that the villager wears.
+            clothing_variation:
+              type: string
+              example: Light Blue
+              description: The variation of the clothing (usually a color).
+            fav_styles:
+              type: array
+              items:
+                type: string
+              example:
+                - Simple
+                - Active
+              description: The villager's favorite clothing styles.
+            fav_colors:
+              type: array
+              items:
+                type: string
+              example:
+                - Blue
+                - Aqua
+              description: >-
+                The villager's favorite colors (giving the villager a gift with
+                one of their favorite colors increases friendship points).
+            hobby:
+              type: string
+              example: Fitness
+              description: >-
+                The villager's primary hobby, which determines most of the
+                activities they will do around the island (e.g. education
+                villagers will frequently read books and visit the museum).
+                Learn more at https://nookipedia.com/wiki/Hobbies
+              enum:
+                - Education
+                - Fashion
+                - Fitness
+                - Music
+                - Nature
+                - Play
+            house_interior_url:
+              type: string
+              example: 'https://dodo.ac/np/images/8/86/House_of_Ribbot_NH.png'
+              description: A screenshot of the villager's house interior.
+            house_exterior_url:
+              type: string
+              example: 'https://dodo.ac/np/images/4/42/House_of_Ribbot_NH_Model.png'
+              description: >-
+                A rendered model of the villager's house exterior. Note that
+                this is not an official Nintendo asset, but a render based of
+                the in-game model.
+            house_wallpaper:
+              type: string
+              example: Circuit-Board Wall
+              description: The wallpaper in the villager's house.
+            house_flooring:
+              type: string
+              example: Future-Tech Flooring
+              description: The flooring in the villager's house.
+            house_music:
+              type: string
+              example: K.K. Technopop
+              description: The music in the villager's house.
+            house_music_note:
+              type: string
+              example: ''
+              description: >-
+                Any notes about the villager's music. This is usually "Does not
+                contain a stereo initially", meaning that the villager's house
+                will not play music unless provided with a stereo.
     NHFish:
       type: object
       properties:
@@ -1054,7 +1166,7 @@ components:
           type: string
           example: '27'
           description: 'In-game fish number, marking position in the Critterpedia.'
-        image:
+        image_url:
           type: string
           example: 'https://dodo.ac/np/images/d/db/Cherry_Salmon_NH_Icon.png'
           description: Image of the fish. dodo.ac is Nookipedia's CDN server.
@@ -1192,7 +1304,7 @@ components:
           type: string
           example: '19'
           description: 'In-game bug number, marking position in the Critterpedia.'
-        image:
+        image_url:
           type: string
           example: 'https://dodo.ac/np/images/3/37/Grasshopper_NH_Icon.png'
           description: Image of the bug. dodo.ac is Nookipedia's CDN server.
@@ -1298,7 +1410,7 @@ components:
           type: string
           example: '20'
           description: 'In-game sea creature number, marking position in the Critterpedia.'
-        image:
+        image_url:
           type: string
           example: 'https://dodo.ac/np/images/5/58/Octopus_NH_Icon.png'
           description: Image of the sea creature. dodo.ac is Nookipedia's CDN server.

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -26,7 +26,7 @@ servers:
 paths:
   /villager:
     get:
-      summary: All villagers
+      summary: Villagers
       description: >-
         All villagers from the entire Animal Crossing series, with the option to
         filter by species and/or personality. Note that villagers only includes
@@ -144,153 +144,18 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Villager'
+        '400':
+          description: One of the inputs (usually query parameters) has an invalid value.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
         '401':
           description: Failed to authenticate user from `X-API-KEY`.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
-        '500':
-          description: There was an error fetching the requested data.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error500'
-  '/villager/{villager}':
-    get:
-      summary: Single villager
-      description: >-
-        Retrieve information about a specific villager. Note that villagers only
-        includes the animals that act as residents. Special characters, such as
-        Tom Nook and Isabelle, are not accessed through this endpoint.
-      parameters:
-        - in: path
-          name: villager
-          required: true
-          schema:
-            type: string
-          description: The name of the villager you wish to retrieve information about.
-        - in: header
-          name: X-API-KEY
-          required: true
-          schema:
-            type: string
-            format: uuid
-          description: >-
-            Your UUID secret key, granted to you by the Nookipedia team.
-            Required for accessing the API.
-        - in: header
-          name: Accept-Version
-          required: true
-          schema:
-            type: string
-          description: >-
-            The version of the API you are calling, written as `1.0.0`. This is
-            specified as required as good practice, but it is not actually
-            enforced by the API. If you do not specify a version, you will be
-            served the latest version, which may eventually result in breaking
-            changes.
-        - in: query
-          name: species
-          required: false
-          schema:
-            type: string
-            enum:
-              - alligator
-              - anteater
-              - bear
-              - bird
-              - bull
-              - cat
-              - cub
-              - chicken
-              - cow
-              - deer
-              - dog
-              - duck
-              - eagle
-              - elephant
-              - frog
-              - goat
-              - gorilla
-              - hamster
-              - hippo
-              - horse
-              - koala
-              - kangaroo
-              - lion
-              - monkey
-              - mouse
-              - octopus
-              - ostrich
-              - penguin
-              - pig
-              - rabbit
-              - rhino
-              - sheep
-              - squirrel
-              - tiger
-              - wolf
-          description: Retrieve villagers of a certain species.
-        - in: query
-          name: personality
-          required: false
-          schema:
-            type: string
-            enum:
-              - lazy
-              - jock
-              - cranky
-              - smug
-              - normal
-              - peppy
-              - snooty
-              - sisterly
-          description: >-
-            Retrieve villagers with a certain personality. For 'sisterly', note
-            that the community often also calls it 'uchi' or 'big sister'.
-        - in: query
-          name: excludedetails
-          required: false
-          schema:
-            type: string
-          description: >-
-            When set to `true`, only villager names are returned. Instead of an
-            array of objects with all details, the return will be an array of
-            strings.
-        - in: query
-          name: thumbsize
-          required: false
-          schema:
-            type: integer
-          description: >-
-            Specify the desired width of returned image URLs. When unspecified,
-            the linked image(s) returned by the API will be full-resolution.
-            Note that images can only be reduced in size; specifying a width
-            greater than than the maximum size will return the default full-size
-            image URL. This parameter is generally not recommended unless you
-            absolutely need it, as each returned thumbnail link with a custom
-            size requires an additional network call, which can result in a long
-            response time if calling this endpoint in between cache refreshes.
-      responses:
-        '200':
-          description: A JSON object describing the villager.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Villager'
-        '401':
-          description: Failed to authenticate user from `X-API-KEY`.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error401'
-        '404':
-          description: Could not find the specified villager.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error404'
         '500':
           description: There was an error fetching the requested data.
           content:

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -872,7 +872,8 @@ components:
             The villager's quote as it appears on the back of their in-game
             portrait item. This will be the quote from the latest game (i.e. if
             the villager had varying quotes between Wild World and New Horizons,
-            this will be the New Horizons quote).
+            this will be the New Horizons quote). For villagers from older games
+            that do not have a quote, this field will be an empty string.
         phrase:
           type: string
           example: zzrrbbit

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -615,7 +615,7 @@ paths:
                 $ref: '#/components/schemas/Error500'
   /nh/sea:
     get:
-      summary: All NH sea creatures
+      summary: All New Horizons sea creatures
       description: >-
         Get a list of all sea creatures and their details in *Animal Crossing:
         New Horizons*. Note that while cached, this endpoint will be very
@@ -705,7 +705,7 @@ paths:
                 $ref: '#/components/schemas/Error500'
   '/nh/sea/{sea_creature}':
     get:
-      summary: Single NH sea creature
+      summary: Single New Horizons sea creature
       description: >-
         Retrieve information about a specific sea creature in *Animal Crossing:
         New Horizons*.

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -28,10 +28,11 @@ paths:
     get:
       summary: Villagers
       description: >-
-        All villagers from the entire Animal Crossing series, with the option to
-        filter by species and/or personality. Note that villagers only includes
-        the animals that act as residents. Special characters, such as Tom Nook
-        and Isabelle, are not accessed through this endpoint.
+        This endpoint retrieves villagers from the entire Animal Crossing
+        series, with the option to filter by species and/or TODO personality.
+        Note that villagers only includes the animals that act as residents.
+        Special characters, such as Tom Nook and Isabelle, are not accessed
+        through this endpoint.
       parameters:
         - in: header
           name: X-API-KEY
@@ -113,6 +114,29 @@ paths:
             Retrieve villagers with a certain personality. For 'sisterly', note
             that the community often also calls it 'uchi' or 'big sister'.
         - in: query
+          name: game
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - DNM
+                - AC
+                - E_PLUS
+                - WW
+                - CF
+                - NL
+                - WA
+                - NH
+                - FILM
+                - HHD
+                - PC
+          description: >-
+            Retrieve villagers that appear in all listed games. If you wanted
+            only villagers that appear in both *New Horizons* and *Pocket Camp*,
+            you would send in `game=nh&game=pc`.
+        - in: query
           name: birthmonth
           required: false
           schema:
@@ -130,13 +154,13 @@ paths:
             Use with `birthmonth` to get villager(s) born on a specific day.
             Value should be an int, 1 through 31.
         - in: query
-          name: includenhdetails
+          name: nhdetails
           required: false
           schema:
             type: string
           description: >-
-            Specify if you would like to also receive the `nh_details` object
-            that contains New Horizons details about the villager.
+            When set to `true`, an `nh_details` object will be included that
+            contains New Horizons details about the villager.
         - in: query
           name: excludedetails
           required: false

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -980,16 +980,21 @@ components:
               example: 'https://dodo.ac/np/images/0/03/RibbotPicACNH.png'
               description: >-
                 The villager's photo, received by the player after attaining a
-                certain friendship level.
+                certain friendship level. See
+                https://nookipedia.com/wiki/Category:New_Horizons_pictures for
+                full list.
             icon_url:
               type: string
               example: 'https://dodo.ac/np/images/8/87/Ribbot_NH_Villager_Icon.png'
-              description: The villager's icon of their head.
+              description: >-
+                The villager's icon of their head. See
+                https://nookipedia.com/wiki/Category:New_Horizons_character_icons
+                for full list.
             quote:
               type: string
               example: 'Never rest, never rust.'
               description: >-
-                The villager's quote, as found on the bac of their in-game
+                The villager's quote, as found on the back of their in-game
                 photo.
             sub-personality:
               type: string
@@ -1075,9 +1080,10 @@ components:
               type: string
               example: ''
               description: >-
-                Any notes about the villager's music. This is usually "Does not
-                contain a stereo initially", meaning that the villager's house
-                will not play music unless provided with a stereo.
+                Any notes about the villager's music. If populated, this is
+                usually "Does not contain a stereo initially", meaning that the
+                villager's house will not play music unless provided with a
+                stereo.
     NHFish:
       type: object
       properties:

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -24,7 +24,7 @@ info:
 servers:
   - url: 'https://api.nookipedia.com/'
 paths:
-  /villager:
+  /villagers:
     get:
       summary: Villagers
       description: >-

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -162,7 +162,9 @@ paths:
             type: string
           description: >-
             When set to `true`, an `nh_details` object will be included that
-            contains New Horizons details about the villager.
+            contains New Horizons details about the villager. If the villager
+            does not appear in *New Horizons*, the returned `nh_details` field
+            will be set to null.
         - in: query
           name: excludedetails
           required: false
@@ -200,7 +202,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error401'
+                $ref: '#/components/schemas/Error400'
         '401':
           description: Failed to authenticate user from `X-API-KEY`.
           content:
@@ -841,7 +843,11 @@ components:
         birthday:
           type: string
           example: February 13
-          description: Birthday of the villager in 'Month Day' form.
+          description: >-
+            Birthday of the villager in 'Month Day' form. Note that villager
+            birthdays were not introduced until *Wild World*. For villagers who
+            didn't appear in *Wild World* or any later games, this field will be
+            an empty string.
         sign:
           type: string
           example: Aquarius
@@ -901,14 +907,15 @@ components:
           type: string
           example: DNM
           description: >-
-            The first Animal Crossing game the villager appeared in. DNM is
-            Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); AC is Animal
-            Crossing for GameCube; E_PLUS is Doubutsu no Mori e+ for GameCube
-            (expanded port of AC, Japan-exclusive); WW is Wild World for the DS;
-            CF is City Folk for Wii; NL is New Leaf for 3DS; WA is Welcome
-            amiibo, the New Leaf expansion; NH is New Horizons for Switch; FILM
-            is the Doubutsu no Mori Japan-exclusive film; HHD is Happy Home
-            Designer for the Wii; and PC is Pocket Camp for mobile.
+            The first Animal Crossing game the villager appeared in. `DNM` is
+            Doubutsu no Mori for the Nintendo 64 (Japan-exclusive); `AC` is
+            Animal Crossing for GameCube; `E_PLUS` is Doubutsu no Mori e+ for
+            GameCube (expanded port of AC, Japan-exclusive); `WW` is Wild World
+            for the DS; `CF` is City Folk for Wii; `NL` is New Leaf for 3DS;
+            `WA` is Welcome amiibo, the New Leaf expansion; NH is New Horizons
+            for Switch; `FILM` is the Doubutsu no Mori Japan-exclusive film;
+            `HHD` is Happy Home Designer for the Wii; and `PC` is Pocket Camp
+            for mobile.
           enum:
             - DNM
             - AC
@@ -949,16 +956,20 @@ components:
             - HHD
             - PC
           description: >-
-            List of official media villager appeared in. DNM is Doubutsu no Mori
-            for the Nintendo 64 (Japan-exclusive); AC is Animal Crossing for
-            GameCube; E_PLUS is Doubutsu no Mori e+ for GameCube (expanded port
-            of AC, Japan-exclusive); WW is Wild World for the DS; CF is City
-            Folk for Wii; NL is New Leaf for 3DS; WA is Welcome amiibo, the New
-            Leaf expansion; NH is New Horizons for Switch; FILM is the Doubutsu
-            no Mori Japan-exclusive film; HHD is Happy Home Designer for the
-            Wii; and PC is Pocket Camp for mobile.
+            List of official media villager appeared in. `DNM` is Doubutsu no
+            Mori for the Nintendo 64 (Japan-exclusive); `AC` is Animal Crossing
+            for GameCube; `E_PLUS` is Doubutsu no Mori e+ for GameCube (expanded
+            port of AC, Japan-exclusive); `WW` is Wild World for the DS; `CF` is
+            City Folk for Wii; `NL` is New Leaf for 3DS; `WA` is Welcome amiibo,
+            the New Leaf expansion; NH is New Horizons for Switch; `FILM` is the
+            Doubutsu no Mori Japan-exclusive film; `HHD` is Happy Home Designer
+            for the Wii; and `PC` is Pocket Camp for mobile.
         nh_details:
           type: object
+          description: >-
+            An object that holds villager data specific to *New Horizons*. If
+            the villager does not appear in *New Horizons*, this field will be
+            set to null.
           properties:
             image_url:
               type: string

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -137,7 +137,7 @@ paths:
             response time if calling this endpoint in between cache refreshes.
       responses:
         '200':
-          description: A JSON array of villagers
+          description: A JSON array of villagers.
           content:
             application/json:
               schema:
@@ -274,7 +274,7 @@ paths:
             response time if calling this endpoint in between cache refreshes.
       responses:
         '200':
-          description: A JSON array of villagers
+          description: A JSON object describing the villager.
           content:
             application/json:
               schema:
@@ -287,6 +287,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '404':
+          description: Could not find the specified villager.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
         '500':
           description: There was an error fetching the requested data.
           content:
@@ -363,7 +369,7 @@ paths:
             response time if calling this endpoint in between cache refreshes.
       responses:
         '200':
-          description: A JSON array of fish
+          description: A JSON array of fish.
           content:
             application/json:
               schema:
@@ -521,7 +527,7 @@ paths:
             response time if calling this endpoint in between cache refreshes.
       responses:
         '200':
-          description: A JSON array of bug
+          description: A JSON array of bugs.
           content:
             application/json:
               schema:
@@ -680,7 +686,7 @@ paths:
             response time if calling this endpoint in between cache refreshes.
       responses:
         '200':
-          description: A JSON array of sea creature
+          description: A JSON array of sea creatures.
           content:
             application/json:
               schema:

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -28,10 +28,10 @@ paths:
     get:
       summary: All villagers
       description: >-
-        All villagers from the entire Animal Crossing series. Note that
-        villagers only includes the animals that act as residents. Special
-        characters, such as Tom Nook and Isabelle, are not accessed through this
-        endpoint.
+        All villagers from the entire Animal Crossing series, with the option to
+        filter by species and/or personality. Note that villagers only includes
+        the animals that act as residents. Special characters, such as Tom Nook
+        and Isabelle, are not accessed through this endpoint.
       parameters:
         - in: header
           name: X-API-KEY
@@ -110,19 +110,154 @@ paths:
               - snooty
               - sisterly
           description: >-
-            Retrieve villagers with a certain personality. For 'sisterly', that
-            the community often also calls it 'uchi' or 'big sister'.
+            Retrieve villagers with a certain personality. For 'sisterly', note
+            that the community often also calls it 'uchi' or 'big sister'.
         - in: query
           name: excludedetails
           required: false
           schema:
             type: string
           description: >-
-            When set to `true`, only fish names are returned. Instead of an
+            When set to `true`, only villager names are returned. Instead of an
             array of objects with all details, the return will be an array of
-            strings. This is particularly useful when used with the `month`
-            filter, for users who want just a list of fish in a given month but
-            not all their respective details.
+            strings.
+        - in: query
+          name: thumbsize
+          required: false
+          schema:
+            type: integer
+          description: >-
+            Specify the desired width of returned image URLs. When unspecified,
+            the linked image(s) returned by the API will be full-resolution.
+            Note that images can only be reduced in size; specifying a width
+            greater than than the maximum size will return the default full-size
+            image URL. This parameter is generally not recommended unless you
+            absolutely need it, as each returned thumbnail link with a custom
+            size requires an additional network call, which can result in a long
+            response time if calling this endpoint in between cache refreshes.
+      responses:
+        '200':
+          description: A JSON array of villagers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Villager'
+        '401':
+          description: Failed to authenticate user from `X-API-KEY`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '500':
+          description: There was an error fetching the requested data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  '/villager/{villager}':
+    get:
+      summary: Single villager
+      description: >-
+        Retrieve information about a specific villager. Note that villagers only
+        includes the animals that act as residents. Special characters, such as
+        Tom Nook and Isabelle, are not accessed through this endpoint.
+      parameters:
+        - in: path
+          name: villager
+          required: true
+          schema:
+            type: string
+          description: The name of the villager you wish to retrieve information about.
+        - in: header
+          name: X-API-KEY
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: >-
+            Your UUID secret key, granted to you by the Nookipedia team.
+            Required for accessing the API.
+        - in: header
+          name: Accept-Version
+          required: true
+          schema:
+            type: string
+          description: >-
+            The version of the API you are calling, written as `1.0.0`. This is
+            specified as required as good practice, but it is not actually
+            enforced by the API. If you do not specify a version, you will be
+            served the latest version, which may eventually result in breaking
+            changes.
+        - in: query
+          name: species
+          required: false
+          schema:
+            type: string
+            enum:
+              - alligator
+              - anteater
+              - bear
+              - bird
+              - bull
+              - cat
+              - cub
+              - chicken
+              - cow
+              - deer
+              - dog
+              - duck
+              - eagle
+              - elephant
+              - frog
+              - goat
+              - gorilla
+              - hamster
+              - hippo
+              - horse
+              - koala
+              - kangaroo
+              - lion
+              - monkey
+              - mouse
+              - octopus
+              - ostrich
+              - penguin
+              - pig
+              - rabbit
+              - rhino
+              - sheep
+              - squirrel
+              - tiger
+              - wolf
+          description: Retrieve villagers of a certain species.
+        - in: query
+          name: personality
+          required: false
+          schema:
+            type: string
+            enum:
+              - lazy
+              - jock
+              - cranky
+              - smug
+              - normal
+              - peppy
+              - snooty
+              - sisterly
+          description: >-
+            Retrieve villagers with a certain personality. For 'sisterly', note
+            that the community often also calls it 'uchi' or 'big sister'.
+        - in: query
+          name: excludedetails
+          required: false
+          schema:
+            type: string
+          description: >-
+            When set to `true`, only villager names are returned. Instead of an
+            array of objects with all details, the return will be an array of
+            strings.
         - in: query
           name: thumbsize
           required: false
@@ -250,7 +385,9 @@ paths:
   '/nh/fish/{fish}':
     get:
       summary: Single New Horizons fish
-      description: Optional extended description in CommonMark or HTML.
+      description: >-
+        Retrieve information about a specific fish in *Animal Crossing: New
+        Horizons*.
       parameters:
         - in: path
           name: fish
@@ -406,7 +543,9 @@ paths:
   '/nh/bugs/{bug}':
     get:
       summary: Single New Horizons bug
-      description: Optional extended description in CommonMark or HTML.
+      description: >-
+        Retrieve information about a specific bug in *Animal Crossing: New
+        Horizons*.
       parameters:
         - in: path
           name: bug
@@ -563,7 +702,9 @@ paths:
   '/nh/sea/{sea_creature}':
     get:
       summary: Single NH sea creature
-      description: Optional extended description in CommonMark or HTML.
+      description: >-
+        Retrieve information about a specific sea creature in *Animal Crossing:
+        New Horizons*.
       parameters:
         - in: path
           name: sea_creature
@@ -755,8 +896,8 @@ components:
           description: >-
             The villager's personality. Note that there are no official in-game
             personality names; these are names that are commonly used by the
-            community. In the case of Sisterly, other common names include Big
-            Sister and Uchi.
+            community. In the case of 'sisterly', other common names include
+            'big sis' and 'uchi'.
           enum:
             - Cranky
             - Jock

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -28,11 +28,11 @@ paths:
     get:
       summary: Villagers
       description: >-
-        This endpoint retrieves villagers from the entire Animal Crossing
-        series, with the option to filter by species and/or TODO personality.
-        Note that villagers only includes the animals that act as residents.
-        Special characters, such as Tom Nook and Isabelle, are not accessed
-        through this endpoint.
+        This endpoint retrieves villager information from the entire Animal
+        Crossing series, with the option to filter by species, personality,
+        game, and/or birthday. Note that villagers only includes the animals
+        that act as residents. Special characters, such as Tom Nook and
+        Isabelle, are not accessed through this endpoint.
       parameters:
         - in: header
           name: X-API-KEY

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -30,9 +30,11 @@ paths:
       description: >-
         This endpoint retrieves villager information from the entire Animal
         Crossing series, with the option to filter by species, personality,
-        game, and/or birthday. Note that villagers only includes the animals
-        that act as residents. Special characters, such as Tom Nook and
-        Isabelle, are not accessed through this endpoint.
+        game, and/or birthday. Filters use the AND operator (e.g. asking for
+        villagers who have species `frog` and personality `smug` will return all
+        smug frogs). Note that villagers only include the animals that act as
+        residents. Special characters, such as Tom Nook and Isabelle, are not
+        accessed through this endpoint.
       parameters:
         - in: header
           name: X-API-KEY
@@ -133,9 +135,9 @@ paths:
                 - HHD
                 - PC
           description: >-
-            Retrieve villagers that appear in all listed games. If you wanted
-            only villagers that appear in both *New Horizons* and *Pocket Camp*,
-            you would send in `game=nh&game=pc`.
+            Retrieve villagers that appear in all listed games. If you want only
+            villagers that appear in both *New Horizons* and *Pocket Camp*, you
+            would send in `?game=nh&game=pc`.
         - in: query
           name: birthmonth
           required: false
@@ -180,10 +182,10 @@ paths:
             the linked image(s) returned by the API will be full-resolution.
             Note that images can only be reduced in size; specifying a width
             greater than than the maximum size will return the default full-size
-            image URL. This parameter is generally not recommended unless you
-            absolutely need it, as each returned thumbnail link with a custom
-            size requires an additional network call, which can result in a long
-            response time if calling this endpoint in between cache refreshes.
+            image URL. When asking for a large list of villagers, this parameter
+            is generally not recommended as the generation of each custom-sized
+            thumbnail requires an additional network call to generate, which can
+            result in a very long response time.
       responses:
         '200':
           description: A JSON array of villagers.


### PR DESCRIPTION
**Villagers endpoint details**

This new `villagers` endpoint queries data for all 480 villagers across the entire series.

You may filter by `name`, `personality`, `species`, `birthday`, and `game` (e.g. if you want a list of all smug frogs that appeared in Wild World, you can do that via `/villagers?personality=smug&species=frog&game=ww`).

The endpoint also allows users to request New Horizons-specific details via the `nhdetails=true` query parameter. The return body will include an `nh_details` object inside, which includes things like house pics, hobby, favorite colors, etc. For villagers that don't appear in NH, this field will have a `null` value.

Note that the return body is an array, because there is no guarantee a query will have just one result. There are two names that are shared by two villagers: Lulu and Petunia. If making a Discord/Twitch bot that looks up via name, users will want to come up with a way to handle these (either return information for both villagers, or have an optional way for users to narrow it down, like querying by both name+species).

**Other changes**
For NH critters: Previously, querying a single NH critter (e.g. `/nh/fish/Sea Bass`) returned an array with one object in it. Now, it will return just the one object. If you're sending in `Accept-Version` w/ version 1.0.0 or 1.0.1, you will continue to receive the array.