### PR TITLE
Recipe endpoints, providing pagination support, other enhancements

### DIFF
--- a/app.py
+++ b/app.py
@@ -317,10 +317,12 @@ def call_cargo(parameters, request_args): # Request args are passed in just for 
                 # If image, fetch the CDN thumbnail URL:
                 try:
                     print(str(obj['title']))
-                    r = requests.get(BASE_URL_WIKI + 'Special:FilePath/' + item['image_url'].rsplit('/', 1)[-1] + '?width=' + request.args.get('thumbsize'))
-                    item['image_url'] = r.url
+                    #Only fetch the image if this object actually has an image to fetch
+                    if 'image_url' in item:
+                        r = requests.get(BASE_URL_WIKI + 'Special:FilePath/' + item['image_url'].rsplit('/', 1)[-1] + '?width=' + request.args.get('thumbsize'))
+                        item['image_url'] = r.url
                     # If this is a painting that has a fake, fetch that too
-                    if item.get('fake','0')=='1':
+                    if item.get('fake')=='1':
                         r = requests.get(BASE_URL_WIKI + 'Special:FilePath/' + item['fake_image_url'].rsplit('/', 1)[-1] + '?width=' + request.args.get('thumbsize'))
                         item['fake_image_url'] = r.url
                 except:

--- a/app.py
+++ b/app.py
@@ -309,8 +309,6 @@ def call_cargo(parameters, request_args): # Request args are passed in just for 
         print('Return: {}'.format(str(r)))
     except:
         print('Return: {}'.format(str(r)))
-        import traceback
-        traceback.print_exc()
         abort(500, description=error_response("Error while calling Nookipedia's Cargo API.", "MediaWiki Cargo request failed for parameters: {}".format(parameters)))
 
     if not cargoquery:

--- a/app.py
+++ b/app.py
@@ -316,7 +316,8 @@ def call_cargo(parameters, request_args): # Request args are passed in just for 
 
                 # If image, fetch the CDN thumbnail URL:
                 try:
-                    r = requests.get(BASE_URL_WIKI + 'Special:FilePath/' + obj['title'][key].rsplit('/', 1)[-1] + '?width=' + request.args.get('thumbsize'))
+                    print(str(obj['title']))
+                    r = requests.get(BASE_URL_WIKI + 'Special:FilePath/' + item['image_url'].rsplit('/', 1)[-1] + '?width=' + request.args.get('thumbsize'))
                     item['image_url'] = r.url
                 except:
                     abort(500, description=error_response("Error while getting image CDN thumbnail URL.", "Failure occured with the following parameters: {}.".format(parameters)))

--- a/app.py
+++ b/app.py
@@ -1002,7 +1002,7 @@ def get_nh_art_all():
     return get_art_list(limit,tables,fields)
 
 @app.route('/nh/recipe/<string:recipe>', methods=['GET'])
-def get_recipe(recipe):
+def get_nh_recipe(recipe):
     authorize(DB_KEYS, request)
 
     if 'Accept-Version' in request.headers and request.headers['Accept-Version'][:3] in ('1.0','1.1','1.2','1.3'):
@@ -1022,7 +1022,7 @@ def get_recipe(recipe):
         return jsonify(format_recipe(cargo_results[0]))
 
 @app.route('/nh/recipe', methods=['GET'])
-def get_recipe_all():
+def get_nh_recipe_all():
     authorize(DB_KEYS, request)
 
     if 'Accept-Version' in request.headers and request.headers['Accept-Version'][:3] in ('1.0','1.1','1.2','1.3'):

--- a/app.py
+++ b/app.py
@@ -302,6 +302,8 @@ def call_cargo(parameters, request_args): # Request args are passed in just for 
         querycount = math.ceil(cargolimit / cargomax) # Determines how many queries we're doing
         for _ in range(0,querycount):
             nestedparameters['limit'] = str(min(cargomax,cargolimit - len(cargoquery))) # Get cargomax items or less at a time
+            if nestedparameters['limit']=='0':
+                break
             nestedparameters['offset'] = str(len(cargoquery))
             r = requests.get(url = BASE_URL_API, params = nestedparameters)
             cargoquery.extend(r.json()['cargoquery'])

--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ import sqlite3
 import uuid
 import json
 import configparser
-import math
 from datetime import datetime
 from flask import Flask
 from flask import abort
@@ -292,24 +291,26 @@ def month_to_string(month):
 def call_cargo(parameters, request_args): # Request args are passed in just for the sake of caching
     cargoquery = []
     try:
-        # The limit for MediaWiki cargo queries, would be changed to 5000 for a bot
-        cargomax = 500
         # The default query size is 50 normally, we can actually change it here if we wanted
         cargolimit = int(parameters.get('limit','50'))
         # Copy the current parameters, we'll be changing them a bit in the loop but we want the original still
         nestedparameters = parameters.copy()
         # Set up the offset, if our cargolimit is more than cargomax we'll end up doing more than one query with an offset
-        querycount = math.ceil(cargolimit / cargomax) # Determines how many queries we're doing
-        for _ in range(0,querycount):
-            nestedparameters['limit'] = str(min(cargomax,cargolimit - len(cargoquery))) # Get cargomax items or less at a time
-            if nestedparameters['limit']=='0':
+        while True:
+            nestedparameters['limit'] = str(cargolimit-len(cargoquery)) # Get cargomax items or less at a time
+            if nestedparameters['limit']=='0': #Check if we've hit the limit
                 break
             nestedparameters['offset'] = str(len(cargoquery))
             r = requests.get(url = BASE_URL_API, params = nestedparameters)
-            cargoquery.extend(r.json()['cargoquery'])
+            cargochunk = r.json()['cargoquery']
+            if len(cargochunk) == 0: #Check if we've hit the end
+                break
+            cargoquery.extend(cargochunk)
         print('Return: {}'.format(str(r)))
     except:
         print('Return: {}'.format(str(r)))
+        import traceback
+        traceback.print_exc()
         abort(500, description=error_response("Error while calling Nookipedia's Cargo API.", "MediaWiki Cargo request failed for parameters: {}".format(parameters)))
 
     if not cargoquery:

--- a/app.py
+++ b/app.py
@@ -480,7 +480,7 @@ def get_villager_list(limit, tables, join, fields):
             where = where + ' AND villager.birthday_month = "' + month + '"'
         else:
             where = 'villager.birthday_month = "' + month + '"'
-    
+
     # Filter by birth day:
     if request.args.get('birthday'):
         day = request.args.get('birthday')
@@ -512,7 +512,7 @@ def get_villager_list(limit, tables, join, fields):
             where = where + ' AND villager.species = "' + species + '"'
         else:
             where = 'villager.species = "' + species + '"'
-    
+
     # Filter by game:
     if request.args.get('game'):
         games = request.args.getlist("game")
@@ -522,7 +522,7 @@ def get_villager_list(limit, tables, join, fields):
                 where = where + ' AND villager.' + game + ' = "1"'
             else:
                 where = 'villager.' + game + ' = "1"'
-    
+
     if where:
         params = { 'action': 'cargoquery', 'format': 'json', 'limit': limit, 'tables': tables, 'join_on': join, 'fields': fields, 'where': where }
     else:
@@ -611,7 +611,7 @@ def format_critters(data):
                 del obj['catchphrase2']
             if 'catchphrase3' in obj:
                 del obj['catchphrase3']
-        
+
         # Create array of times and corresponding months for those times:
         availability_array_north = [ {'months': obj['time_n_months'], 'time': obj['time'] } ]
         availability_array_south = [ {'months': obj['time_s_months'], 'time': obj['time'] } ]
@@ -727,7 +727,7 @@ def format_art(data):
         data['has_fake']=True
     elif data['has_fake']=='0':
         data['has_fake']=False
-    
+
     # Integers
     data['buy_price']=int(data['buy_price'])
     data['sell_price']=int(data['sell_price'])
@@ -985,7 +985,7 @@ def get_nh_art(art):
         abort(404, description=error_response("No data was found for the given query.", f"MediaWiki Cargo request succeeded by nothing was returned for the parameters: {params}"))
     else:
         return jsonify(format_art(cargo_results[0]))
-    
+
 
 @app.route('/nh/art', methods=['GET'])
 def get_nh_art_all():

--- a/app.py
+++ b/app.py
@@ -768,8 +768,6 @@ def format_recipe(data):
     data['serial_id'] = int('0'+data['serial_id'])
     data['sell'] = int('0'+data['sell']) if data['sell'] != 'NA' else 0
     data['recipes_to_unlock'] = int('0'+data['recipes_to_unlock'])
-    data['buy1_price'] = int('0'+data['buy1_price'])
-    data['buy2_price'] = int('0'+data['buy2_price'])
 
     # Change the material# and material#_num columns to be one materials column
     data['materials'] = []
@@ -781,6 +779,28 @@ def format_recipe(data):
             })
         del data[f'material{i}']
         del data[f'material{i}_num']
+    
+        
+    data['diy_availability'] = []
+    for i in range(1,3):
+        if len(data[f'diy_availability{i}']) > 0:
+            data['diy_availability'].append({
+                'from':data[f'diy_availability{i}'],
+                'note':data[f'diy_availability{i}_note']
+            })
+        del data[f'diy_availability{i}']
+        del data[f'diy_availability{i}_note']
+    
+    # Do the same for buy#_price and buy#_currency columns
+    data['buy'] = []
+    for i in range(1,3): # Technically overkill, but it'd be easy to add a third buy column if it ever matters
+        if len(data[f'buy{i}_price']) > 0:
+            data['buy'].append({
+                'price':int(data[f'buy{i}_price']),
+                'currency':data[f'buy{i}_currency']
+            })
+        del data[f'buy{i}_price']
+        del data[f'buy{i}_currency']
     return data
 
 def get_recipe_list(limit,tables,fields):

--- a/app.py
+++ b/app.py
@@ -879,10 +879,11 @@ def get_nh_fish_all():
 def get_nh_fish(fish):
     authorize(DB_KEYS, request)
     fish = fish.replace('_', ' ')
+    limit = '1'
     tables = 'nh_fish'
     fields = 'name,_pageName=url,number,image_url,catchphrase,catchphrase2,catchphrase3,location,shadow_size,rarity,total_catch,sell_nook,sell_cj,tank_width,tank_length,time,time_n_availability=time_n_months,time_s_availability=time_s_months,time2,time2_n_availability=time2_n_months,time2_s_availability=time2_s_months,n_availability,n_m1,n_m2,n_m3,n_m4,n_m5,n_m6,n_m7,n_m8,n_m9,n_m10,n_m11,n_m12,n_m1_time,n_m2_time,n_m3_time,n_m4_time,n_m5_time,n_m6_time,n_m7_time,n_m8_time,n_m9_time,n_m10_time,n_m11_time,n_m12_time,s_availability,s_m1,s_m2,s_m3,s_m4,s_m5,s_m6,s_m7,s_m8,s_m9,s_m10,s_m11,s_m12,s_m1_time,s_m2_time,s_m3_time,s_m4_time,s_m5_time,s_m6_time,s_m7_time,s_m8_time,s_m9_time,s_m10_time,s_m11_time,s_m12_time'
     where = 'name="' + fish + '"'
-    params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'fields': fields, 'where': where }
+    params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'fields': fields, 'where': where, 'limit': limit }
 
     cargo_results = call_cargo(params, request.args)
     if cargo_results == []:
@@ -913,10 +914,11 @@ def get_nh_bug(bug):
     authorize(DB_KEYS, request)
 
     bug = bug.replace('_', ' ')
+    limit = '1'
     tables = 'nh_bug'
     fields = 'name,_pageName=url,number,image_url,catchphrase,catchphrase2,location,rarity,total_catch,sell_nook,sell_flick,tank_width,tank_length,time,time_n_availability=time_n_months,time_s_availability=time_s_months,time2,time2_n_availability=time2_n_months,time2_s_availability=time2_s_months,n_availability,n_m1,n_m2,n_m3,n_m4,n_m5,n_m6,n_m7,n_m8,n_m9,n_m10,n_m11,n_m12,n_m1_time,n_m2_time,n_m3_time,n_m4_time,n_m5_time,n_m6_time,n_m7_time,n_m8_time,n_m9_time,n_m10_time,n_m11_time,n_m12_time,s_availability,s_m1,s_m2,s_m3,s_m4,s_m5,s_m6,s_m7,s_m8,s_m9,s_m10,s_m11,s_m12,s_m1_time,s_m2_time,s_m3_time,s_m4_time,s_m5_time,s_m6_time,s_m7_time,s_m8_time,s_m9_time,s_m10_time,s_m11_time,s_m12_time'
     where = 'name="' + bug + '"'
-    params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'fields': fields, 'where': where }
+    params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'fields': fields, 'where': where, 'limit': limit }
 
     cargo_results = call_cargo(params, request.args)
     if cargo_results == []:
@@ -947,10 +949,11 @@ def get_nh_sea(sea):
     authorize(DB_KEYS, request)
 
     sea = sea.replace('_', ' ')
+    limit = '1'
     tables = 'nh_sea_creature'
     fields = 'name,_pageName=url,number,image_url,catchphrase,catchphrase2,shadow_size,shadow_movement,rarity,total_catch,sell_nook,tank_width,tank_length,time,time_n_availability=time_n_months,time_s_availability=time_s_months,time2,time2_n_availability=time2_n_months,time2_s_availability=time2_s_months,n_availability,n_m1,n_m2,n_m3,n_m4,n_m5,n_m6,n_m7,n_m8,n_m9,n_m10,n_m11,n_m12,n_m1_time,n_m2_time,n_m3_time,n_m4_time,n_m5_time,n_m6_time,n_m7_time,n_m8_time,n_m9_time,n_m10_time,n_m11_time,n_m12_time,s_availability,s_m1,s_m2,s_m3,s_m4,s_m5,s_m6,s_m7,s_m8,s_m9,s_m10,s_m11,s_m12,s_m1_time,s_m2_time,s_m3_time,s_m4_time,s_m5_time,s_m6_time,s_m7_time,s_m8_time,s_m9_time,s_m10_time,s_m11_time,s_m12_time'
     where = 'name="' + sea + '"'
-    params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'fields': fields, 'where': where }
+    params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'fields': fields, 'where': where, 'limit': limit }
 
     cargo_results = call_cargo(params, request.args)
     if cargo_results == []:
@@ -969,10 +972,11 @@ def get_art(art):
         abort(404, description=error_response('Resource not found.', 'Please ensure requested resource exists.'))
 
     art = art.replace('_', ' ')
+    limit = '1'
     tables = 'nh_art'
     fields = 'name,image,image_url,fake,fake_image,fake_image_url,art_name,author,year,art_style,description,buy_price,sell_price,availability,authenticity,width,length'
     where = f'name="{art}"'
-    params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'fields': fields, 'where': where }
+    params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'fields': fields, 'where': where, 'limit': limit }
 
     cargo_results = call_cargo(params, request.args)
     if cargo_results == []:

--- a/app.py
+++ b/app.py
@@ -785,8 +785,11 @@ def format_recipe(data):
 
 def get_recipe_list(limit,tables,fields):
     where = None
+
     if 'material' in request.args:
-        materials = request.args['material'].split(',')
+        materials = request.args.getlist('material')
+        if len(materials) > 6:
+            abort(400, description=error_response('Invalid arguments','Cannot have more than six materials'))
         for m in materials:
             m.replace('_',' ')
             if where is None:

--- a/app.py
+++ b/app.py
@@ -786,7 +786,7 @@ def get_recipe_list(limit,tables,fields):
     results_array = []
     if request.args.get('excludedetails') == 'true':
         for recipe in cargo_results:
-            results_array.append(recipe['identifier'])
+            results_array.append(recipe['en_name'])
     else:
         for recipe in cargo_results:
             results_array.append(format_recipe(recipe))
@@ -981,6 +981,26 @@ def get_art_all():
     
     return get_art_list(limit,tables,fields)
 
+
+@app.route('/nh/recipe/<string:recipe>', methods=['GET'])
+def get_recipe(recipe):
+    authorize(DB_KEYS, request)
+
+    if 'Accept-Version' in request.headers and request.headers['Accept-Version'][:3] in ('1.0','1.1','1.2','1.3'):
+        abort(404, description=error_response('Resource not found.', 'Please ensure requested resource exists.'))
+    
+    recipe = recipe.replace('_',' ')
+    tables = 'nh_recipe'
+    fields = 'en_name,image,serial_id,sell,recipes_to_unlock,diy_availability1,diy_availability1_note,diy_availability2,diy_availability2_note,material1,material1_num,material2,material2_num,material3,material3_num,material4,material4_num,material5,material5_num,material6,material6_num'
+    where = f'en_name="{recipe}"'
+    params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'fields': fields, 'where': where }
+
+    cargo_results = call_cargo(params, request.args)
+    if len(cargo_results) == 0:
+        abort(404, description=error_response("No data was found for the given query.", f"MediaWiki Cargo request succeeded by nothing was returned for the parameters: {params}"))
+    else:
+        return jsonify(format_recipe(cargo_results[0]))
+
 @app.route('/nh/recipe', methods=['GET'])
 def get_recipe_all():
     authorize(DB_KEYS, request)
@@ -990,7 +1010,7 @@ def get_recipe_all():
     
     limit='600'
     tables = 'nh_recipe'
-    fields = 'identifier,en_name,image,serial_id,sell,recipes_to_unlock,diy_availability1,diy_availability1_note,diy_availability2,diy_availability2_note,material1,material1_num,material2,material2_num,material3,material3_num,material4,material4_num,material5,material5_num,material6,material6_num'
+    fields = 'en_name,image,serial_id,sell,recipes_to_unlock,diy_availability1,diy_availability1_note,diy_availability2,diy_availability2_note,material1,material1_num,material2,material2_num,material3,material3_num,material4,material4_num,material5,material5_num,material6,material6_num'
 
     return get_recipe_list(limit,tables,fields)
     

--- a/app.py
+++ b/app.py
@@ -767,6 +767,8 @@ def format_recipe(data):
     data['serial_id'] = int('0'+data['serial_id'])
     data['sell'] = int('0'+data['sell']) if data['sell'] != 'NA' else 0
     data['recipes_to_unlock'] = int('0'+data['recipes_to_unlock'])
+    data['buy1_price'] = int('0'+data['buy1_price'])
+    data['buy2_price'] = int('0'+data['buy2_price'])
 
     # Change the material# and material#_num columns to be one materials column
     data['materials'] = []
@@ -1004,10 +1006,11 @@ def get_recipe(recipe):
         abort(404, description=error_response('Resource not found.', 'Please ensure requested resource exists.'))
     
     recipe = recipe.replace('_',' ')
+    limit = '1'
     tables = 'nh_recipe'
-    fields = 'en_name,image,serial_id,sell,recipes_to_unlock,diy_availability1,diy_availability1_note,diy_availability2,diy_availability2_note,material1,material1_num,material2,material2_num,material3,material3_num,material4,material4_num,material5,material5_num,material6,material6_num'
+    fields = 'en_name,image,image_url,serial_id,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,recipes_to_unlock,diy_availability1,diy_availability1_note,diy_availability2,diy_availability2_note,material1,material1_num,material2,material2_num,material3,material3_num,material4,material4_num,material5,material5_num,material6,material6_num'
     where = f'en_name="{recipe}"'
-    params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'fields': fields, 'where': where }
+    params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'fields': fields, 'where': where, 'limit': limit}
 
     cargo_results = call_cargo(params, request.args)
     if len(cargo_results) == 0:
@@ -1024,7 +1027,7 @@ def get_recipe_all():
     
     limit='600'
     tables = 'nh_recipe'
-    fields = 'en_name,image,serial_id,sell,recipes_to_unlock,diy_availability1,diy_availability1_note,diy_availability2,diy_availability2_note,material1,material1_num,material2,material2_num,material3,material3_num,material4,material4_num,material5,material5_num,material6,material6_num'
+    fields = 'en_name,image,image_url,serial_id,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,recipes_to_unlock,diy_availability1,diy_availability1_note,diy_availability2,diy_availability2_note,material1,material1_num,material2,material2_num,material3,material3_num,material4,material4_num,material5,material5_num,material6,material6_num'
 
     return get_recipe_list(limit,tables,fields)
     

--- a/static/doc.json
+++ b/static/doc.json
@@ -754,6 +754,172 @@
           }
         }
       }
+    },
+    "/nh/art": {
+      "get": {
+        "summary": "All New Horizons artwork",
+        "description": "Get a list of all artwork and their details in *Animal Crossing: New Horizons*. Note that while cached, this endpoint will be very responsive; however, hitting the endpoint in between cache refreshes can result in a response time of 5 to 15 seconds.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-API-KEY",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Your UUID secret key, granted to you by the Nookipedia team. Required for accessing the API."
+          },
+          {
+            "in": "header",
+            "name": "Accept-Version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
+          },
+          {
+            "in": "query",
+            "name": "fake",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "When set to `true`, only artwork that has a fake will be returned. When set to `false`, only artwork without fakes will be returned."
+          },
+          {
+            "in": "query",
+            "name": "excludedetails",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "When set to `true`, only artwork names are returned. Instead of an array of objects with all details, the return will be an array of strings."
+          },
+          {
+            "in": "query",
+            "name": "thumbsize",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Specify the desired width of returned image URLs. When unspecified, the linked image(s) returned by the API will be full-resolution. Note that images can only be reduced in size; specifying a width greater than than the maximum size will return the default full-size image URL. This parameter is generally not recommended unless you absolutely need it, as each returned thumbnail link with a custom size requires an additional network call, which can result in a long response time if calling this endpoint in between cache refreshes."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A JSON array of artwork.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NHArtwork"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Failed to authenticate user from `X-API-KEY`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error401"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was an error fetching the requested data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error500"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nh/art/{artwork}": {
+      "get": {
+        "summary": "Single New Horizons artwork",
+        "description": "Retrieve information about a specific artwork in *Animal Crossing: New Horizons*.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "artwork",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name of the artwork you wish to retrieve information about."
+          },
+          {
+            "in": "header",
+            "name": "X-API-KEY",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Your UUID secret key, granted to you by the Nookipedia team. Required for accessing the API."
+          },
+          {
+            "in": "header",
+            "name": "Accept-Version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
+          },
+          {
+            "in": "query",
+            "name": "thumbsize",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Specify the desired width of returned image URLs. When unspecified, the linked image(s) returned by the API will be full-resolution. Note that images can only be reduced in size; specifying a width greater than than the maximum size will return the default full-size image URL. This parameter is generally not recommended unless you absolutely need it, as each returned thumbnail link with a custom size requires an additional network call, which can result in a long response time if calling this endpoint in between cache refreshes."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A JSON object describing the artwork.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NHArtwork"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Failed to authenticate user from `X-API-KEY`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error401"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was an error fetching the requested data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error500"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -819,6 +985,98 @@
             "type": "string",
             "example": "Details unknown.",
             "description": "A more in-depth description of the issue, including parameters and/or error text when available."
+          }
+        }
+      },
+      "NHArtwork": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "Academic Painting",
+            "description": "Name of the artwork"
+          },
+          "image": {
+            "type": "string",
+            "example": "Academic Painting NH Icon.png",
+            "description": "The image for the real artwork"
+          },
+          "image_url": {
+            "type": "string",
+            "example": "https://dodo.ac/np/images/e/e8/Academic_Painting_NH_Icon.png",
+            "description": "The image URL for the real artwork"
+          },
+          "fake": {
+            "type": "boolean",
+            "example": true,
+            "description": "Whether the artwork has a fake or not"
+          },
+          "fake_image": {
+            "type": "string",
+            "example": "Academic Painting (Forgery) NH Icon.png",
+            "description": "The image for the fake artwork, if it exists"
+          },
+          "fake_image_url": {
+            "type": "string",
+            "example": "https://dodo.ac/np/images/1/13/Academic_Painting_%28Forgery%29_NH_Icon.png",
+            "description": "The image url for the fake artwork, if it exists"
+          },
+          "art_name": {
+            "type": "string",
+            "example": "Vitruvian Man",
+            "description": "The name of the real-life analog to the artwork"
+          },
+          "author": {
+            "type": "string",
+            "example": "Leonardo da Vinci",
+            "description": "The author of the real-life analog to the artwork"
+          },
+          "year": {
+            "type": "string",
+            "example": "circa 1487",
+            "description": "The year that the real-life analog was made"
+          },
+          "art_style": {
+            "type": "string",
+            "example": "Pen and ink on paper",
+            "description": "The art style of the artwork"
+          },
+          "description": {
+            "type": "string",
+            "example": "This drawing is based on the &quot;ideal&quot; human-body ratio, as stated in &quot;De architectura.&quot; &quot;De architectura&quot; was a treatise by Vitruvius, an architect from the early 1st century BCE.",
+            "description": "The description of the artwork"
+          },
+          "buy_price": {
+            "type": "integer",
+            "example": 4980,
+            "description": "The buy price of the artwork"
+          },
+          "sell_price": {
+            "type": "integer",
+            "example": 1245,
+            "description": "The sell price of the artwork"
+          },
+          "availability": {
+            "type": "string",
+            "example": "Jolly Redd's Treasure Trawler",
+            "description": "The availability of the artwork"
+          },
+          "authenticity": {
+            "type": "string",
+            "example": "If there is a coffee stain in the top right corner, it is fake. If there is no stain, it is genuine. The forgery has a key taped to the back of the canvas.",
+            "description": "The description of the difference between real and fake, if there is one"
+          },
+          "width": {
+            "type": "number",
+            "format": "float",
+            "example": 1,
+            "description": "The width of the artwork"
+          },
+          "length": {
+            "type": "number",
+            "format": "float",
+            "example": 1,
+            "description": "The length of the artwork"
           }
         }
       },

--- a/static/doc.json
+++ b/static/doc.json
@@ -2435,10 +2435,35 @@
             "example": "Acoustic Guitar  NH DIY Icon.png",
             "description": "The image for the recipe."
           },
+          "image_url": {
+            "type": "string",
+            "example": "https://dodo.ac/np/images/0/07/Acoustic_Guitar_NH_DIY_Icon.png",
+            "description": "The image url for the recipe."
+          },
           "serial_id": {
             "type": "integer",
             "example": 406,
             "description": "The unique ID of the recipe."
+          },
+          "buy1_price": {
+            "type": "integer",
+            "example": 0,
+            "description": "The primary price of the recipe"
+          },
+          "buy1_currency": {
+            "type": "string",
+            "example": "",
+            "description": "The primary currency the recipe is purchased with"
+          },
+          "buy2_price": {
+            "type": "integer",
+            "example": 0,
+            "description": "The secondary price of the recipe"
+          },
+          "buy2_currency": {
+            "type": "string",
+            "example": "",
+            "description": "The secondary currency the recipe is purchased with"
           },
           "sell": {
             "type": "integer",

--- a/static/doc.json
+++ b/static/doc.json
@@ -920,6 +920,83 @@
           }
         }
       }
+    },
+    "/nh/recipe": {
+      "get": {
+        "summary": "All New Horizons recipes",
+        "description": "Get a list of all artwork and their details in *Animal Crossing: New Horizons*. Note that while cached, this endpoint will be very responsive; however, hitting the endpoint in between cache refreshes can result in a response time of 5 to 15 seconds.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-API-KEY",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Your UUID secret key, granted to you by the Nookipedia team. Required for accessing the API."
+          },
+          {
+            "in": "header",
+            "name": "Accept-Version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
+          },
+          {
+            "in": "query",
+            "name": "material",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A comma-seperated list of materials to filter with."
+          },
+          {
+            "in": "query",
+            "name": "thumbsize",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Specify the desired width of returned image URLs. When unspecified, the linked image(s) returned by the API will be full-resolution. Note that images can only be reduced in size; specifying a width greater than than the maximum size will return the default full-size image URL. This parameter is generally not recommended unless you absolutely need it, as each returned thumbnail link with a custom size requires an additional network call, which can result in a long response time if calling this endpoint in between cache refreshes."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A JSON object describing the artwork.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NHRecipe"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Failed to authenticate user from `X-API-KEY`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error401"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was an error fetching the requested data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error500"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -2249,6 +2326,86 @@
               12
             ],
             "description": "An array of integers representing the months the sea creature is available in the Southern hemisphere."
+          }
+        }
+      },
+      "NHRecipe": {
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "example": "Acoustic Guitar",
+            "description": "The name of the recipe."
+          },
+          "en_name": {
+            "type": "string",
+            "example": "Acoustic Guitar",
+            "description": "The english name of the recipe."
+          },
+          "image": {
+            "type": "string",
+            "example": "Acoustic Guitar  NH DIY Icon.png",
+            "description": "The image for the recipe."
+          },
+          "serial_id": {
+            "type": "integer",
+            "example": 406,
+            "description": "The unique ID of the recipe."
+          },
+          "sell": {
+            "type": "integer",
+            "example": 200,
+            "description": "The sell price of the recipe."
+          },
+          "recipes_to_unlock": {
+            "type": "integer",
+            "example": 0,
+            "description": "How many recipes to need to unlock this one."
+          },
+          "diy_availability1": {
+            "type": "string",
+            "example": "Smug Villager",
+            "description": "The source of the recipe."
+          },
+          "diy_availability1_note": {
+            "type": "string",
+            "example": "",
+            "description": "Any notes on the source of the recipe."
+          },
+          "diy_availability2": {
+            "type": "string",
+            "example": "",
+            "description": "A secondary source of the recipe, if it exists."
+          },
+          "diy_availability2_note": {
+            "type": "string",
+            "example": "",
+            "description": "Any notes on the secondary source of the recipe."
+          },
+          "materials": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "count": {
+                  "type": "integer"
+                }
+              }
+            },
+            "example": [
+              {
+                "name": "Softwood",
+                "count": 8
+              },
+              {
+                "name": "Iron Nugget",
+                "count": 3
+              }
+            ],
+            "description": "The list of materials required to craft the recipe"
           }
         }
       }

--- a/static/doc.json
+++ b/static/doc.json
@@ -908,6 +908,16 @@
               }
             }
           },
+          "404": {
+            "description": "Could not find the specified recipe.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error404"
+                }
+              }
+            }
+          },
           "500": {
             "description": "There was an error fetching the requested data.",
             "content": {
@@ -924,7 +934,7 @@
     "/nh/recipe": {
       "get": {
         "summary": "All New Horizons recipes",
-        "description": "Get a list of all artwork and their details in *Animal Crossing: New Horizons*. Note that while cached, this endpoint will be very responsive; however, hitting the endpoint in between cache refreshes can result in a response time of 5 to 15 seconds.",
+        "description": "Get a list of all recipes and their details in *Animal Crossing: New Horizons*. Note that while cached, this endpoint will be very responsive; however, hitting the endpoint in between cache refreshes can result in a response time of 5 to 15 seconds.",
         "parameters": [
           {
             "in": "header",
@@ -966,11 +976,94 @@
         ],
         "responses": {
           "200": {
-            "description": "A JSON object describing the artwork.",
+            "description": "A JSON array of recipes.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NHRecipe"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NHRecipe"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Failed to authenticate user from `X-API-KEY`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error401"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "There was an error fetching the requested data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error500"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nh/recipe/{recipe}": {
+      "get": {
+        "summary": "Single New Horizons recipe",
+        "description": "Retrieve information about a specific recipe in Animal Crossing: New Horizons.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "recipe",
+            "required": true,
+            "description": "The name of the recipe you wish to retrieve information about.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-API-KEY",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Your UUID secret key, granted to you by the Nookipedia team. Required for accessing the API."
+          },
+          {
+            "in": "header",
+            "name": "Accept-Version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The version of the API you are calling, written as `1.0.0`. This is specified as required as good practice, but it is not actually enforced by the API. If you do not specify a version, you will be served the latest version, which may eventually result in breaking changes."
+          },
+          {
+            "in": "query",
+            "name": "thumbsize",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Specify the desired width of returned image URLs. When unspecified, the linked image(s) returned by the API will be full-resolution. Note that images can only be reduced in size; specifying a width greater than than the maximum size will return the default full-size image URL. This parameter is generally not recommended unless you absolutely need it, as each returned thumbnail link with a custom size requires an additional network call, which can result in a long response time if calling this endpoint in between cache refreshes."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A JSON array of recipes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NHRecipe"
+                  }
                 }
               }
             }
@@ -2332,15 +2425,10 @@
       "NHRecipe": {
         "type": "object",
         "properties": {
-          "identifier": {
-            "type": "string",
-            "example": "Acoustic Guitar",
-            "description": "The name of the recipe."
-          },
           "en_name": {
             "type": "string",
             "example": "Acoustic Guitar",
-            "description": "The english name of the recipe."
+            "description": "The name of the recipe."
           },
           "image": {
             "type": "string",

--- a/static/doc.json
+++ b/static/doc.json
@@ -2255,10 +2255,10 @@
             "example": "Acoustic Guitar",
             "description": "The name of the recipe."
           },
-          "image": {
+          "url": {
             "type": "string",
-            "example": "Acoustic Guitar  NH DIY Icon.png",
-            "description": "The image for the recipe."
+            "example": "https://nookipedia.com/wiki/Item:Acoustic_Guitar_(New_Horizons)",
+            "description": "The url for the recipe."
           },
           "image_url": {
             "type": "string",

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -849,6 +849,75 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /nh/recipe:
+    get:
+      summary: All New Horizons recipes
+      description: >-
+        Get a list of all artwork and their details in *Animal Crossing: New
+        Horizons*. Note that while cached, this endpoint will be very
+        responsive; however, hitting the endpoint in between cache refreshes can
+        result in a response time of 5 to 15 seconds.
+      parameters:
+        - in: header
+          name: X-API-KEY
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: >-
+            Your UUID secret key, granted to you by the Nookipedia team.
+            Required for accessing the API.
+        - in: header
+          name: Accept-Version
+          required: true
+          schema:
+            type: string
+          description: >-
+            The version of the API you are calling, written as `1.0.0`. This is
+            specified as required as good practice, but it is not actually
+            enforced by the API. If you do not specify a version, you will be
+            served the latest version, which may eventually result in breaking
+            changes.
+        - in: query
+          name: material
+          required: false
+          schema:
+            type: string
+          description: "A comma-seperated list of materials to filter with."
+        - in: query
+          name: thumbsize
+          required: false
+          schema:
+            type: integer
+          description: >-
+            Specify the desired width of returned image URLs. When unspecified,
+            the linked image(s) returned by the API will be full-resolution.
+            Note that images can only be reduced in size; specifying a width
+            greater than than the maximum size will return the default full-size
+            image URL. This parameter is generally not recommended unless you
+            absolutely need it, as each returned thumbnail link with a custom
+            size requires an additional network call, which can result in a long
+            response time if calling this endpoint in between cache refreshes.
+      responses:
+        '200':
+          description: A JSON object describing the artwork.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NHRecipe'
+        '401':
+          description: Failed to authenticate user from `X-API-KEY`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '500':
+          description: There was an error fetching the requested data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+        
 components:
   schemas:
     Error400:
@@ -2086,3 +2155,61 @@ components:
           description: >-
             An array of integers representing the months the sea creature is
             available in the Southern hemisphere.
+    NHRecipe:
+      type: object
+      properties:
+        identifier:
+          type: string
+          example: "Acoustic Guitar"
+          description: "The name of the recipe."
+        en_name:
+          type: string
+          example: "Acoustic Guitar"
+          description: "The english name of the recipe."
+        image:
+          type: string
+          example: "Acoustic Guitar  NH DIY Icon.png"
+          description: "The image for the recipe."
+        serial_id:
+          type: integer
+          example: 406
+          description: "The unique ID of the recipe."
+        sell:
+          type: integer
+          example: 200
+          description: "The sell price of the recipe."
+        recipes_to_unlock:
+          type: integer
+          example: 0
+          description: "How many recipes to need to unlock this one."
+        diy_availability1:
+          type: string
+          example: "Smug Villager"
+          description: "The source of the recipe."
+        diy_availability1_note:
+          type: string
+          example: ""
+          description: "Any notes on the source of the recipe."
+        diy_availability2:
+          type: string
+          example: ""
+          description: "A secondary source of the recipe, if it exists."
+        diy_availability2_note:
+          type: string
+          example: ""
+          description: "Any notes on the secondary source of the recipe."
+        materials:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              count:
+                type: integer
+          example:
+            - name: "Softwood"
+              count: 8
+            - name: "Iron Nugget"
+              count: 3
+          description: "The list of materials required to craft the recipe"

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -2089,10 +2089,10 @@ components:
           type: string
           example: "Acoustic Guitar"
           description: "The name of the recipe."
-        image:
+        url:
           type: string
-          example: "Acoustic Guitar  NH DIY Icon.png"
-          description: "The image for the recipe."
+          example: "https://nookipedia.com/wiki/Item:Acoustic_Guitar_(New_Horizons)"
+          description: "The url for the recipe."
         image_url:
           type: string
           example: "https://dodo.ac/np/images/0/07/Acoustic_Guitar_NH_DIY_Icon.png"

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -2241,10 +2241,30 @@ components:
           type: string
           example: "Acoustic Guitar  NH DIY Icon.png"
           description: "The image for the recipe."
+        image_url:
+          type: string
+          example: "https://dodo.ac/np/images/0/07/Acoustic_Guitar_NH_DIY_Icon.png"
+          description: "The image url for the recipe."
         serial_id:
           type: integer
           example: 406
           description: "The unique ID of the recipe."
+        buy1_price:
+          type: integer
+          example: 0
+          description: "The primary price of the recipe"
+        buy1_currency:
+          type: string
+          example: ""
+          description: "The primary currency the recipe is purchased with"
+        buy2_price:
+          type: integer
+          example: 0
+          description: "The secondary price of the recipe"
+        buy2_currency:
+          type: string
+          example: ""
+          description: "The secondary currency the recipe is purchased with"
         sell:
           type: integer
           example: 200

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -843,6 +843,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '404':
+          description: Could not find the specified recipe.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404'
         '500':
           description: There was an error fetching the requested data.
           content:
@@ -853,7 +859,7 @@ paths:
     get:
       summary: All New Horizons recipes
       description: >-
-        Get a list of all artwork and their details in *Animal Crossing: New
+        Get a list of all recipes and their details in *Animal Crossing: New
         Horizons*. Note that while cached, this endpoint will be very
         responsive; however, hitting the endpoint in between cache refreshes can
         result in a response time of 5 to 15 seconds.
@@ -900,11 +906,80 @@ paths:
             response time if calling this endpoint in between cache refreshes.
       responses:
         '200':
-          description: A JSON object describing the artwork.
+          description: A JSON array of recipes.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NHRecipe'
+                type: array
+                items:
+                  $ref: '#/components/schemas/NHRecipe'
+        '401':
+          description: Failed to authenticate user from `X-API-KEY`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '500':
+          description: There was an error fetching the requested data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  "/nh/recipe/{recipe}":
+    get:
+      summary: Single New Horizons recipe
+      description: >-
+        Retrieve information about a specific recipe in Animal Crossing: New Horizons.
+      parameters:
+        - in: path
+          name: recipe
+          required: true
+          description: The name of the recipe you wish to retrieve information about.
+          schema:
+            type: string
+        - in: header
+          name: X-API-KEY
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: >-
+            Your UUID secret key, granted to you by the Nookipedia team.
+            Required for accessing the API.
+        - in: header
+          name: Accept-Version
+          required: true
+          schema:
+            type: string
+          description: >-
+            The version of the API you are calling, written as `1.0.0`. This is
+            specified as required as good practice, but it is not actually
+            enforced by the API. If you do not specify a version, you will be
+            served the latest version, which may eventually result in breaking
+            changes.
+        - in: query
+          name: thumbsize
+          required: false
+          schema:
+            type: integer
+          description: >-
+            Specify the desired width of returned image URLs. When unspecified,
+            the linked image(s) returned by the API will be full-resolution.
+            Note that images can only be reduced in size; specifying a width
+            greater than than the maximum size will return the default full-size
+            image URL. This parameter is generally not recommended unless you
+            absolutely need it, as each returned thumbnail link with a custom
+            size requires an additional network call, which can result in a long
+            response time if calling this endpoint in between cache refreshes.
+      responses:
+        '200':
+          description: A JSON array of recipes.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NHRecipe'
         '401':
           description: Failed to authenticate user from `X-API-KEY`.
           content:
@@ -2158,14 +2233,10 @@ components:
     NHRecipe:
       type: object
       properties:
-        identifier:
-          type: string
-          example: "Acoustic Guitar"
-          description: "The name of the recipe."
         en_name:
           type: string
           example: "Acoustic Guitar"
-          description: "The english name of the recipe."
+          description: "The name of the recipe."
         image:
           type: string
           example: "Acoustic Guitar  NH DIY Icon.png"

--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -702,6 +702,153 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error500'
+  /nh/art:
+    get:
+      summary: All New Horizons artwork
+      description: >-
+        Get a list of all artwork and their details in *Animal Crossing: New
+        Horizons*. Note that while cached, this endpoint will be very
+        responsive; however, hitting the endpoint in between cache refreshes can
+        result in a response time of 5 to 15 seconds.
+      parameters:
+        - in: header
+          name: X-API-KEY
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: >-
+            Your UUID secret key, granted to you by the Nookipedia team.
+            Required for accessing the API.
+        - in: header
+          name: Accept-Version
+          required: true
+          schema:
+            type: string
+          description: >-
+            The version of the API you are calling, written as `1.0.0`. This is
+            specified as required as good practice, but it is not actually
+            enforced by the API. If you do not specify a version, you will be
+            served the latest version, which may eventually result in breaking
+            changes.
+        - in: query
+          name: fake
+          required: false
+          schema:
+            type: string
+          description: >-
+            When set to `true`, only artwork that has a fake will be returned.
+            When set to `false`, only artwork without fakes will be returned.
+        - in: query
+          name: excludedetails
+          required: false
+          schema:
+            type: string
+          description: >-
+            When set to `true`, only artwork names are returned. Instead of an
+            array of objects with all details, the return will be an array of
+            strings.
+        - in: query
+          name: thumbsize
+          required: false
+          schema:
+            type: integer
+          description: >-
+            Specify the desired width of returned image URLs. When unspecified,
+            the linked image(s) returned by the API will be full-resolution.
+            Note that images can only be reduced in size; specifying a width
+            greater than than the maximum size will return the default full-size
+            image URL. This parameter is generally not recommended unless you
+            absolutely need it, as each returned thumbnail link with a custom
+            size requires an additional network call, which can result in a long
+            response time if calling this endpoint in between cache refreshes.
+      responses:
+        '200':
+          description: A JSON array of artwork.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NHArtwork'
+        '401':
+          description: Failed to authenticate user from `X-API-KEY`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '500':
+          description: There was an error fetching the requested data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  '/nh/art/{artwork}':
+    get:
+      summary: Single New Horizons artwork
+      description: >-
+        Retrieve information about a specific artwork in *Animal Crossing:
+        New Horizons*.
+      parameters:
+        - in: path
+          name: artwork
+          required: true
+          schema:
+            type: string
+          description: The name of the artwork you wish to retrieve information about.
+        - in: header
+          name: X-API-KEY
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: >-
+            Your UUID secret key, granted to you by the Nookipedia team.
+            Required for accessing the API.
+        - in: header
+          name: Accept-Version
+          required: true
+          schema:
+            type: string
+          description: >-
+            The version of the API you are calling, written as `1.0.0`. This is
+            specified as required as good practice, but it is not actually
+            enforced by the API. If you do not specify a version, you will be
+            served the latest version, which may eventually result in breaking
+            changes.
+        - in: query
+          name: thumbsize
+          required: false
+          schema:
+            type: integer
+          description: >-
+            Specify the desired width of returned image URLs. When unspecified,
+            the linked image(s) returned by the API will be full-resolution.
+            Note that images can only be reduced in size; specifying a width
+            greater than than the maximum size will return the default full-size
+            image URL. This parameter is generally not recommended unless you
+            absolutely need it, as each returned thumbnail link with a custom
+            size requires an additional network call, which can result in a long
+            response time if calling this endpoint in between cache refreshes.
+      responses:
+        '200':
+          description: A JSON object describing the artwork.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NHArtwork'
+        '401':
+          description: Failed to authenticate user from `X-API-KEY`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        '500':
+          description: There was an error fetching the requested data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
 components:
   schemas:
     Error400:
@@ -762,6 +909,89 @@ components:
           description: >-
             A more in-depth description of the issue, including parameters
             and/or error text when available.
+    NHArtwork:
+      type: object
+      properties:
+        name:
+          type: string
+          example: Academic Painting
+          description: Name of the artwork
+        image:
+          type: string
+          example: Academic Painting NH Icon.png
+          description: The image for the real artwork
+        image_url:
+          type: string
+          example: 'https://dodo.ac/np/images/e/e8/Academic_Painting_NH_Icon.png'
+          description: The image URL for the real artwork
+        fake:
+          type: boolean
+          example: true
+          description: Whether the artwork has a fake or not
+        fake_image:
+          type: string
+          example: Academic Painting (Forgery) NH Icon.png
+          description: 'The image for the fake artwork, if it exists'
+        fake_image_url:
+          type: string
+          example: >-
+            https://dodo.ac/np/images/1/13/Academic_Painting_%28Forgery%29_NH_Icon.png
+          description: 'The image url for the fake artwork, if it exists'
+        art_name:
+          type: string
+          example: Vitruvian Man
+          description: The name of the real-life analog to the artwork
+        author:
+          type: string
+          example: Leonardo da Vinci
+          description: The author of the real-life analog to the artwork
+        year:
+          type: string
+          example: circa 1487
+          description: The year that the real-life analog was made
+        art_style:
+          type: string
+          example: Pen and ink on paper
+          description: The art style of the artwork
+        description:
+          type: string
+          example: >-
+            This drawing is based on the &quot;ideal&quot; human-body ratio, as
+            stated in &quot;De architectura.&quot; &quot;De architectura&quot;
+            was a treatise by Vitruvius, an architect from the early 1st century
+            BCE.
+          description: The description of the artwork
+        buy_price:
+          type: integer
+          example: 4980
+          description: The buy price of the artwork
+        sell_price:
+          type: integer
+          example: 1245
+          description: The sell price of the artwork
+        availability:
+          type: string
+          example: Jolly Redd's Treasure Trawler
+          description: The availability of the artwork
+        authenticity:
+          type: string
+          example: >-
+            If there is a coffee stain in the top right
+            corner, it is fake. If there is no stain, it is genuine. The forgery
+            has a key taped to the back of the canvas.
+          description: >-
+            The description of the difference between real and fake, if there is
+            one
+        width:
+          type: number
+          format: float
+          example: 1
+          description: The width of the artwork
+        length:
+          type: number
+          format: float
+          example: 1
+          description: The length of the artwork
     Villager:
       type: object
       properties:


### PR DESCRIPTION
All changes made:
- `/nh/recipe` and `/nh/recipe/{recipe}` endpoints have been added. (#20)
- `/nh/recipe` endpoint can have `?material=item1,item2,...`, to filter by materials.
- `call_cargo` can return an entire query, instead of being limited to `500`. (chains `&offset` queries according to `limit`)
- Having `thumbsize` and `excludedetails` in the same query will no longer raise a 500 error, it instead ignores `thumbsize`. (#23)*
- `thumbsize` will no longer raise a 500 error if there isn't an `image_url` column, it will instead be ignored.
- All endpoints that query a single item (`/nh/sea/{sea}`,`/nh/fish/{fish}`,etc) now have a query limit of 1 item.

\* The fix for #23 doesn't raise a 401 error as suggested in the issue, I figured it was cleaner to just ignore it the same as normal extraneous parameters. Could easily be changed if need be.