### PR TITLE
Added fossil endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -1481,11 +1481,8 @@ def stitch_variation(item,variations):
 def get_fossil_list(limit, tables, join, fields):
     where = []
 
-    if len(where) == 0:
-        params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'join_on': join, 'fields': fields, 'limit': limit }
-    else:
-        where = ' AND '.join(where)
-        params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'join_on': join, 'fields': fields, 'limit': limit, 'where': where }
+    params = { 'action': 'cargoquery', 'format': 'json', 'tables': tables, 'join_on': join, 'fields': fields, 'limit': limit }
+    params_where(params, where)
 
     cargo_results = call_cargo(params, request.args)
     results_array = []
@@ -1498,26 +1495,14 @@ def get_fossil_list(limit, tables, join, fields):
     return jsonify(results_array)
 
 def format_fossil(data):
-    data['sell'] = int(data['sell'])
-    data['hha_base'] = int(data['hha_base'])
-    data['room'] = int(data['room'])
-
-    data['width'] = float(data['width'])
-    data['length'] = float(data['length'])
-
-    if data['interactable'] == '0':
-        data['interactable'] = False
-    elif data['interactable'] == '1':
-        data['interactable'] = True
+    format_as_type(data, as_int, 'sell', 'hha_base', 'room')
+    format_as_type(data, as_float, 'width', 'length')
+    format_as_type(data, as_int, 'interactable')
     
-    colors = set()
-    for i in range(1,3):
-        color = f'color{i}'
-        if len(data[color]) > 0:
-            colors.add(data[color])
-        del data[color]
-    colors.discard('None')
-    data['colors'] = list(colors)
+    coalesce_fields_as_list(data, 2, 'colors', 'color{}')
+    data['colors'] = set(data['colors'])
+    data['colors'].discard('None')
+    data['colors'] = list(data['colors'])
 
     return data
 


### PR DESCRIPTION
Fossils endpoint (Resolves #7)

There are a few reasons this is a draft PR atm
- Fossil tables don't have an `image_url` column, and just generally don't seem to be as fletched out as other tables, although that's more a matter of preference.
- I'm not sure how I feel about the way the tables are joined, explained below

I'm not sure how `nh_fossil` and `nh_fossil_group` should be joined

1. We could attach `nh_fossil` data as lists to `nh_fossil_group`, but that makes it so it would be `/nh/fossils/<groupname>`, and to search by raw name you'd do `/nh/fossils?name=`

2. Alternatively, we can attach `nh_fossil_group` to `nh_fossil` (as it is right now), but that duplicates group info a lot, so you get several of the same description attached to different fossils. However, the name searches are swapped, so you get something like `/nh/fossils/<name>` and `/nh/fossils?group=`

3. The last way is to have `/nh/fossils/<name>` not return group data except group name, and have a separate endpoint `/nh/fossil_groups/<group>` *(name just an example)* to return groups with lists of specific fossils.

So the first and second only involve one endpoint, but return single element lists when searching by `name` or `group`, respectively. The last one solves that issue but splits fossils into two endpoints.