### PR TITLE
Quick fix to remove duplicates from cargoquery

### DIFF
--- a/nookipedia/cargo.py
+++ b/nookipedia/cargo.py
@@ -156,8 +156,15 @@ def call_cargo(parameters, request_args):  # Request args are passed in just for
 
     try:
         data = []
-        # Check if user requested specific image size and modify accordingly:
+        
+        # Remove duplicate objects to resolve Cargo duplicate issues:
+        results = []
         for obj in cargoquery:
+            if obj not in results:
+                results.append(obj)
+
+        # Check if user requested specific image size and modify accordingly:
+        for obj in results:
             item = {}
 
             # Replace all spaces in keys with underscores

--- a/nookipedia/cargo.py
+++ b/nookipedia/cargo.py
@@ -156,7 +156,7 @@ def call_cargo(parameters, request_args):  # Request args are passed in just for
 
     try:
         data = []
-        
+
         # Remove duplicate objects to resolve Cargo duplicate issues:
         results = []
         for obj in cargoquery:


### PR DESCRIPTION
Nookipedia's Cargo databases sometimes have duplicate entries due to a bug; this change removes duplicate objects from the cargoquery to avoid giving our API users dupes.

Still need to do some testing.