### PR TITLE
Fix for variation pulling and stitching

### DIFF
--- a/nookipedia/api/acnh/art.py
+++ b/nookipedia/api/acnh/art.py
@@ -1,6 +1,6 @@
+import requests
 from flask import abort, jsonify, request, Blueprint
 
-import requests
 from nookipedia.config import DB_KEYS
 from nookipedia.middlewares import authorize
 from nookipedia.cargo import call_cargo, get_art_list

--- a/nookipedia/api/acnh/bugs.py
+++ b/nookipedia/api/acnh/bugs.py
@@ -1,6 +1,6 @@
+import requests
 from flask import abort, jsonify, request, Blueprint
 
-import requests
 from nookipedia.config import DB_KEYS
 from nookipedia.middlewares import authorize
 from nookipedia.cargo import call_cargo, get_critter_list

--- a/nookipedia/api/acnh/clothing.py
+++ b/nookipedia/api/acnh/clothing.py
@@ -1,3 +1,4 @@
+import requests
 from flask import abort, jsonify, request, Blueprint
 
 from nookipedia.config import DB_KEYS

--- a/nookipedia/api/acnh/clothing.py
+++ b/nookipedia/api/acnh/clothing.py
@@ -17,7 +17,7 @@ def get_nh_clothing(clothing):
     clothing = requests.utils.unquote(clothing).replace("_", " ")
     clothing_limit = "1"
     clothing_tables = "nh_clothing"
-    clothing_fields = "identifier,_pageName=url,en_name=name,category,style1,style2,label1,label2,label3,label4,label5,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,variation_total,vill_equip,seasonality,version_added,unlocked,notes"
+    clothing_fields = "_pageName=url,en_name=name,category,style1,style2,label1,label2,label3,label4,label5,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,variation_total,vill_equip,seasonality,version_added,unlocked,notes"
     clothing_where = f'en_name = "{clothing}"'
     clothing_params = {
         "action": "cargoquery",
@@ -29,7 +29,7 @@ def get_nh_clothing(clothing):
     }
     variation_limit = "10"
     variation_tables = "nh_clothing_variation"
-    variation_fields = "identifier,variation,image_url,color1,color2"
+    variation_fields = "en_name=name,variation,image_url,color1,color2"
     variation_where = f'en_name = "{clothing}"'
     variation_orderby = "variation_number"
     variation_params = {
@@ -71,10 +71,10 @@ def get_nh_clothing_all():
 
     clothing_limit = "1350"
     clothing_tables = "nh_clothing"
-    clothing_fields = "identifier,_pageName=url,en_name=name,category,style1,style2,label1,label2,label3,label4,label5,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,variation_total,vill_equip,seasonality,version_added,unlocked,notes"
+    clothing_fields = "_pageName=url,en_name=name,category,style1,style2,label1,label2,label3,label4,label5,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,variation_total,vill_equip,seasonality,version_added,unlocked,notes"
     variation_limit = "5000"
     variation_tables = "nh_clothing_variation"
-    variation_fields = "identifier,variation,image_url,color1,color2"
+    variation_fields = "en_name=name,variation,image_url,color1,color2"
     variation_orderby = "variation_number"
 
     clothing_list = get_clothing_list(clothing_limit, clothing_tables, clothing_fields)

--- a/nookipedia/api/acnh/fish.py
+++ b/nookipedia/api/acnh/fish.py
@@ -1,6 +1,6 @@
+import requests
 from flask import abort, jsonify, request, Blueprint
 
-import requests
 from nookipedia.config import DB_KEYS
 from nookipedia.middlewares import authorize
 from nookipedia.cargo import call_cargo, get_critter_list

--- a/nookipedia/api/acnh/fossils.py
+++ b/nookipedia/api/acnh/fossils.py
@@ -1,6 +1,6 @@
+import requests
 from flask import abort, jsonify, request, Blueprint
 
-import requests
 from nookipedia.config import DB_KEYS
 from nookipedia.middlewares import authorize
 from nookipedia.cargo import (

--- a/nookipedia/api/acnh/furniture.py
+++ b/nookipedia/api/acnh/furniture.py
@@ -1,3 +1,4 @@
+import requests
 from flask import abort, jsonify, request, Blueprint
 
 from nookipedia.config import DB_KEYS

--- a/nookipedia/api/acnh/furniture.py
+++ b/nookipedia/api/acnh/furniture.py
@@ -17,7 +17,7 @@ def get_nh_furniture(furniture):
     furniture = requests.utils.unquote(furniture).replace("_", " ")
     furniture_limit = "1"
     furniture_tables = "nh_furniture"
-    furniture_fields = "identifier,_pageName=url,en_name=name,category,item_series,item_set,theme1,theme2,hha_category,tag,hha_base,lucky,lucky_season,function1,function2,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,availability3,availability3_note,variation_total,pattern_total,customizable,custom_kits,custom_kit_type,custom_body_part,custom_pattern_part,grid_size,height,door_decor,version_added,unlocked,notes"  #'
+    furniture_fields = "_pageName=url,en_name=name,category,item_series,item_set,theme1,theme2,hha_category,tag,hha_base,lucky,lucky_season,function1,function2,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,availability3,availability3_note,variation_total,pattern_total,customizable,custom_kits,custom_kit_type,custom_body_part,custom_pattern_part,grid_size,height,door_decor,version_added,unlocked,notes"  #'
     furniture_where = f'en_name = "{furniture}"'
     furniture_params = {
         "action": "cargoquery",
@@ -29,7 +29,7 @@ def get_nh_furniture(furniture):
     }
     variation_limit = "70"
     variation_tables = "nh_furniture_variation"
-    variation_fields = "identifier,variation,pattern,image_url,color1,color2"
+    variation_fields = "en_name=name,variation,pattern,image_url,color1,color2"
     variation_where = f'en_name = "{furniture}"'
     variation_orderby = "variation_number,pattern_number"
     variation_params = {
@@ -71,10 +71,10 @@ def get_nh_furniture_all():
 
     furniture_limit = "1300"
     furniture_tables = "nh_furniture"
-    furniture_fields = "identifier,_pageName=url,en_name=name,category,item_series,item_set,theme1,theme2,hha_category,tag,hha_base,lucky,lucky_season,function1,function2,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,availability3,availability3_note,variation_total,pattern_total,customizable,custom_kits,custom_kit_type,custom_body_part,custom_pattern_part,grid_size,height,door_decor,version_added,unlocked,notes"  #'
+    furniture_fields = "_pageName=url,en_name=name,category,item_series,item_set,theme1,theme2,hha_category,tag,hha_base,lucky,lucky_season,function1,function2,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,availability3,availability3_note,variation_total,pattern_total,customizable,custom_kits,custom_kit_type,custom_body_part,custom_pattern_part,grid_size,height,door_decor,version_added,unlocked,notes"  #'
     variation_limit = "6000"
     variation_tables = "nh_furniture_variation"
-    variation_fields = "identifier,variation,pattern,image_url,color1,color2"
+    variation_fields = "en_name=name,variation,pattern,image_url,color1,color2"
     variation_orderby = "variation_number,pattern_number"
 
     furniture_list = get_furniture_list(furniture_limit, furniture_tables, furniture_fields)

--- a/nookipedia/api/acnh/interior.py
+++ b/nookipedia/api/acnh/interior.py
@@ -1,3 +1,4 @@
+import requests
 from flask import abort, jsonify, request, Blueprint
 
 from nookipedia.config import DB_KEYS

--- a/nookipedia/api/acnh/items.py
+++ b/nookipedia/api/acnh/items.py
@@ -1,3 +1,4 @@
+import requests
 from flask import abort, jsonify, request, Blueprint
 
 from nookipedia.config import DB_KEYS

--- a/nookipedia/api/acnh/photos.py
+++ b/nookipedia/api/acnh/photos.py
@@ -1,3 +1,4 @@
+import requests
 from flask import abort, jsonify, request, Blueprint
 
 from nookipedia.config import DB_KEYS

--- a/nookipedia/api/acnh/photos.py
+++ b/nookipedia/api/acnh/photos.py
@@ -17,7 +17,7 @@ def get_nh_photo(photo):
     photo = requests.utils.unquote(photo).replace("_", " ")
     photo_limit = "1"
     photo_tables = "nh_photo"
-    photo_fields = "identifier,_pageName=url,en_name=name,category,hha_base,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,customizable,custom_kits,custom_body_part,grid_size,interactable,version_added,unlocked"
+    photo_fields = "_pageName=url,en_name=name,category,hha_base,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,customizable,custom_kits,custom_body_part,grid_size,interactable,version_added,unlocked"
     photo_where = f'en_name = "{photo}"'
     photo_params = {
         "action": "cargoquery",
@@ -29,7 +29,7 @@ def get_nh_photo(photo):
     }
     variation_limit = "10"
     variation_tables = "nh_photo_variation"
-    variation_fields = "identifier,variation,image_url,color1,color2"
+    variation_fields = "en_name=name,variation,image_url,color1,color2"
     variation_where = f'en_name = "{photo}"'
     variation_orderby = "variation_number"
     variation_params = {
@@ -71,10 +71,10 @@ def get_nh_photo_all():
 
     photo_limit = "900"
     photo_tables = "nh_photo"
-    photo_fields = "identifier,_pageName=url,en_name=name,category,hha_base,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,customizable,custom_kits,custom_body_part,grid_size,interactable,version_added,unlocked"
+    photo_fields = "_pageName=url,en_name=name,category,hha_base,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,customizable,custom_kits,custom_body_part,grid_size,interactable,version_added,unlocked"
     variation_limit = "3700"
     variation_tables = "nh_photo_variation"
-    variation_fields = "identifier,variation,image_url,color1,color2"
+    variation_fields = "en_name=name,variation,image_url,color1,color2"
     variation_orderby = "variation_number"
 
     photo_list = get_photo_list(photo_limit, photo_tables, photo_fields)

--- a/nookipedia/api/acnh/sea.py
+++ b/nookipedia/api/acnh/sea.py
@@ -1,6 +1,6 @@
+import requests
 from flask import abort, jsonify, request, Blueprint
 
-import requests
 from nookipedia.config import DB_KEYS
 from nookipedia.middlewares import authorize
 from nookipedia.cargo import call_cargo, get_critter_list

--- a/nookipedia/api/acnh/tools.py
+++ b/nookipedia/api/acnh/tools.py
@@ -1,3 +1,4 @@
+import requests
 from flask import abort, jsonify, request, Blueprint
 
 from nookipedia.config import DB_KEYS

--- a/nookipedia/api/acnh/tools.py
+++ b/nookipedia/api/acnh/tools.py
@@ -17,7 +17,7 @@ def get_nh_tool(tool):
     tool = requests.utils.unquote(tool).replace("_", " ")
     tool_limit = "1"
     tool_tables = "nh_tool"
-    tool_fields = "identifier,_pageName=url,en_name=name,uses,hha_base,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,availability3,availability3_note,customizable,custom_kits,custom_body_part,version_added,unlocked,notes"
+    tool_fields = "_pageName=url,en_name=name,uses,hha_base,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,availability3,availability3_note,customizable,custom_kits,custom_body_part,version_added,unlocked,notes"
     tool_where = f'en_name = "{tool}"'
     tool_params = {
         "action": "cargoquery",
@@ -29,7 +29,7 @@ def get_nh_tool(tool):
     }
     variation_limit = "10"
     variation_tables = "nh_tool_variation"
-    variation_fields = "identifier,variation,image_url"
+    variation_fields = "en_name=name,variation,image_url"
     variation_where = f'en_name = "{tool}"'
     variation_orderby = "variation_number"
     variation_params = {
@@ -71,10 +71,10 @@ def get_nh_tool_all():
 
     tool_limit = "100"
     tool_tables = "nh_tool"
-    tool_fields = "identifier,_pageName=url,en_name=name,uses,hha_base,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,availability3,availability3_note,customizable,custom_kits,custom_body_part,version_added,unlocked,notes"
+    tool_fields = "_pageName=url,en_name=name,uses,hha_base,buy1_price,buy1_currency,buy2_price,buy2_currency,sell,availability1,availability1_note,availability2,availability2_note,availability3,availability3_note,customizable,custom_kits,custom_body_part,version_added,unlocked,notes"
     variation_limit = "300"
     variation_tables = "nh_tool_variation"
-    variation_fields = "identifier,variation,image_url"
+    variation_fields = "en_name=name,variation,image_url"
     variation_orderby = "variation_number"
 
     tool_list = get_tool_list(tool_limit, tool_tables, tool_fields)

--- a/nookipedia/models.py
+++ b/nookipedia/models.py
@@ -543,14 +543,14 @@ def format_variation(data):
 
 def stitch_variation_list(items, variations):
     ret = {
-        _["identifier"]: _ for _ in items
-    }  # Turn the list of items into a dictionary with the identifier as the key
-    for identifier in ret:
-        ret[identifier]["variations"] = []  # Initialize every variations list
+        _["name"]: _ for _ in items
+    }  # Turn the list of items into a dictionary with the name as the key
+    for name in ret:
+        ret[name]["variations"] = []  # Initialize every variations list
     for variation in variations:
-        if variation["identifier"] in ret:
-            ret[variation["identifier"]]["variations"].append(format_variation(variation))
-            del variation["identifier"]
+        if variation["name"] in ret:
+            ret[variation["name"]]["variations"].append(format_variation(variation))
+            del variation["name"]
 
     # Drop the keys, basically undo what we did at the start
     ret = list(ret.values())
@@ -559,7 +559,6 @@ def stitch_variation_list(items, variations):
     for piece in ret:
         if len(piece["variations"]) == 0:  # If we filtered out all the variations, skip this piece
             continue
-        del piece["identifier"]
         processed.append(piece)
     return processed
 
@@ -568,8 +567,6 @@ def stitch_variation(item, variations):
     item["variations"] = []
     for variation in variations:
         item["variations"].append(format_variation(variation))
-        del variation["identifier"]
-    del item["identifier"]
     return item
 
 


### PR DESCRIPTION
Previously we were treating ACNH items' `identifier` field as, well, a unique identifier; it's a misnomer, as the identifier is used on Nookipedia to track items across all games (e.g. a furniture item that appears in both New Leaf and New Horizons will have the same identifier, even if the item's name changed between the games); multiple items can have the same identifier within a game, so we can't reliably use it as a unique identifier when querying. This PR changes the variation pulling and stitching to use `en_name`/`name` instead, which is an actual identifier.

Also importing missing `requests` in some files.