### PR TITLE
Fix `cub`, `rhino` and `sisterly` in docs

### DIFF
--- a/static/doc.yaml
+++ b/static/doc.yaml
@@ -39,6 +39,7 @@ paths:
               - alligator
               - anteater
               - bear
+              - bear cub
               - bird
               - bull
               - cat
@@ -67,6 +68,7 @@ paths:
               - pig
               - rabbit
               - rhino
+              - rhinoceros
               - sheep
               - squirrel
               - tiger
@@ -78,14 +80,15 @@ paths:
           schema:
             type: string
             enum:
-              - lazy
-              - jock
+              - big sister
               - cranky
-              - smug
+              - jock
+              - lazy
               - normal
               - peppy
-              - snooty
               - sisterly
+              - smug
+              - snooty
           description: 'Retrieve villagers with a certain personality. For ''sisterly'', note that the community often also calls it ''uchi'' or ''big sister''.'
         - in: query
           name: game
@@ -1861,10 +1864,10 @@ components:
             - Alligator
             - Anteater
             - Bear
+            - Bear cub
             - Bird
             - Bull
             - Cat
-            - Cub
             - Chicken
             - Cow
             - Deer
@@ -1888,7 +1891,7 @@ components:
             - Penguin
             - Pig
             - Rabbit
-            - Rhino
+            - Rhinoceros
             - Sheep
             - Squirrel
             - Tiger
@@ -1898,12 +1901,12 @@ components:
           example: Jock
           description: 'The villager''s personality. Note that there are no official in-game personality names; these are names that are commonly used by the community. In the case of ''sisterly'', other common names include ''big sis'' and ''uchi''.'
           enum:
+            - Big sister
             - Cranky
             - Jock
             - Lazy
             - Normal
             - Peppy
-            - Sisterly
             - Smug
             - Snooty
         gender:


### PR DESCRIPTION
It looks like in previous versions of the API, the species `Bear cub` and `Rhinoceros` and the personality `Big sister` were being converted to `Cub`, `Rhino` and `Sisterly` respectively. In both the query and formatter code.

https://github.com/Nookipedia/nookipedia-api/blob/c0ea49bed69d55db668e7fc0218e27f14916d6c7/nookipedia/models.py#L21-L27

However, in versions past `1.3` this is no longer the case. In the query code `cub`, `rhino` and `sisterly` are being converted to their proper, more verbose aliases. While in the formatter code, they are being set to `Bear cub`, `Rhinoceros` and `Big sister`

https://github.com/Nookipedia/nookipedia-api/blob/c0ea49bed69d55db668e7fc0218e27f14916d6c7/nookipedia/cargo.py#L280-L281
https://github.com/Nookipedia/nookipedia-api/blob/c0ea49bed69d55db668e7fc0218e27f14916d6c7/nookipedia/cargo.py#L335-L338

This PR corrects the `doc.yaml` to correctly reflect these cases by adding the proper names to the query enums and replacing the aliases with the proper names in the response enums.
